### PR TITLE
fix: use build output path for releases

### DIFF
--- a/.github/workflows/library.yaml
+++ b/.github/workflows/library.yaml
@@ -413,13 +413,13 @@ jobs:
         uses: actions/upload-artifact@v7.0.1
         with:
           name: prerelease-python-package-distributions
-          path: projects/dist/*
+          path: dist/*
           if-no-files-found: error
 
       - name: Publish pre-release to PyPI (Trusted Publishing)
         uses: pypa/gh-action-pypi-publish@v1.14.0
         with:
-          packages-dir: projects/dist
+          packages-dir: dist
           repository-url: https://test.pypi.org/legacy/
           skip-existing: true
           verbose: true
@@ -515,13 +515,13 @@ jobs:
         uses: actions/upload-artifact@v7.0.1
         with:
           name: release-python-package-distributions
-          path: projects/dist/*
+          path: dist/*
           if-no-files-found: error
 
       - name: Publish to PyPI (Trusted Publishing)
         if: github.event.inputs.release_type != 'prerelease'
         uses: pypa/gh-action-pypi-publish@v1.14.0
         with:
-          packages-dir: projects/dist
+          packages-dir: dist
           skip-existing: true
           verbose: true


### PR DESCRIPTION
## Summary

- read release artifacts from `dist/`, where `uv build --all-packages` writes them
- apply the same correction to pre-release and full-release upload/publish steps

## Failure fixed

The latest `pre-release` deployment failed in Actions run 29661044835 because `actions/upload-artifact` searched `projects/dist/*`. The preceding build logged successful outputs under repository-root `dist/`, so artifact upload failed and TestPyPI publishing was skipped.

## Verification

- `pixi run -e build --frozen lint`
- `pixi run -e build --frozen build-lib`
- verified `dist/dagster_slurm-1.14.0rc4.tar.gz`
- verified `dist/dagster_slurm-1.14.0rc4-py3-none-any.whl`

Fixes the failed [pre-release deployment](https://github.com/ascii-supply-networks/dagster-slurm/deployments/pre-release).