### PR TITLE
fix: remote Slurm environment packaging input staging

### DIFF
--- a/projects/dagster-slurm/dagster_slurm/pipes_clients/slurm_pipes_client.py
+++ b/projects/dagster-slurm/dagster_slurm/pipes_clients/slurm_pipes_client.py
@@ -10,6 +10,8 @@ import shlex
 import signal
 import subprocess
 import sys
+import tarfile
+import tempfile
 import threading
 import time
 import uuid
@@ -1640,15 +1642,27 @@ class SlurmPipesClient(PipesClient):
         self.logger.info(
             "Staging %s small pack input file(s) on the Slurm edge node", len(files)
         )
-        ssh_pool.run(f"mkdir -p {shlex.quote(remote_project_dir)}")
-        for local_path, relative_path in files:
-            remote_path = _remote_join_under_root(
-                root=remote_pack_root,
-                base=remote_project_dir,
-                relative_path=relative_path,
+        remote_archive = _remote_join_under_root(
+            root=remote_pack_root,
+            base=remote_pack_root,
+            relative_path="remote-pack-inputs.tar",
+        )
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            archive_path = Path(tmp_dir) / "remote-pack-inputs.tar"
+            with tarfile.open(archive_path, "w") as archive:
+                for local_path, relative_path in files:
+                    archive.add(local_path, arcname=relative_path, recursive=False)
+
+            ssh_pool.run(
+                f"mkdir -p {shlex.quote(remote_pack_root)} "
+                f"{shlex.quote(remote_project_dir)}"
             )
-            ssh_pool.run(f"mkdir -p {shlex.quote(posixpath.dirname(remote_path))}")
-            ssh_pool.upload_file(str(local_path), remote_path)
+            ssh_pool.upload_file(str(archive_path), remote_archive)
+
+        ssh_pool.run(
+            f"tar -xf {shlex.quote(remote_archive)} "
+            f"-C {shlex.quote(remote_project_dir)}"
+        )
 
     def _pack_environment_on_remote(
         self,

--- a/projects/dagster-slurm/dagster_slurm/pipes_clients/slurm_pipes_client.py
+++ b/projects/dagster-slurm/dagster_slurm/pipes_clients/slurm_pipes_client.py
@@ -1561,6 +1561,10 @@ class SlurmPipesClient(PipesClient):
         scripts, selected cache source globs, and already-built inject artifacts.
         Payload scripts and per-run extra files are handled by the normal ad hoc
         upload path, so script/config edits do not require re-shipping the env.
+
+        Paths are returned relative to the workspace root (not the project dir)
+        so that inputs above the project dir in monorepo layouts stage without
+        ``..`` archive members, which remote tar refuses to extract.
         """
         files: dict[str, Path] = {}
         workspace_root = _local_pack_workspace_root(project_dir)
@@ -1570,17 +1574,12 @@ class SlurmPipesClient(PipesClient):
                 return
             resolved = path.resolve()
             try:
-                resolved.relative_to(workspace_root)
+                relative = resolved.relative_to(workspace_root)
             except ValueError as exc:
                 raise ValueError(
                     "Remote packing input file is outside the local workspace "
                     f"root {workspace_root}: {resolved}"
                 ) from exc
-
-            try:
-                relative = resolved.relative_to(project_dir.resolve())
-            except ValueError:
-                relative = Path(os.path.relpath(resolved, project_dir.resolve()))
             files[relative.as_posix()] = resolved
 
         for name in ("pyproject.toml", "pixi.toml", "pixi.lock"):
@@ -1629,15 +1628,31 @@ class SlurmPipesClient(PipesClient):
     def _stage_remote_pack_workspace(
         self,
         ssh_pool: SSHConnectionPool,
-        remote_project_dir: str,
+        remote_pack_root: str,
         pack_cmds: list[list[str]],
-    ) -> None:
-        """Upload the small set of files needed to run pixi-pack remotely."""
+    ) -> str:
+        """Upload the small set of files needed to run pixi-pack remotely.
+
+        The staged files mirror the local workspace layout under
+        ``<remote_pack_root>/workspace`` so relative references such as
+        ``--inject ../dist/*.whl`` resolve on the edge node. Returns the remote
+        directory corresponding to the local project dir.
+        """
         project_dir = Path.cwd()
+        workspace_root = _local_pack_workspace_root(project_dir)
         files = self._remote_pack_input_files(pack_cmds, project_dir=project_dir)
         if not files:
             raise RuntimeError("Remote packing could not find any local pack inputs")
-        remote_pack_root = posixpath.dirname(remote_project_dir)
+
+        remote_workspace = f"{remote_pack_root}/workspace"
+        project_relative = Path(
+            os.path.relpath(project_dir.resolve(), workspace_root)
+        ).as_posix()
+        remote_project_dir = _remote_join_under_root(
+            root=remote_pack_root,
+            base=remote_workspace,
+            relative_path=project_relative,
+        )
 
         self.logger.info(
             "Staging %s small pack input file(s) on the Slurm edge node", len(files)
@@ -1651,18 +1666,23 @@ class SlurmPipesClient(PipesClient):
             archive_path = Path(tmp_dir) / "remote-pack-inputs.tar"
             with tarfile.open(archive_path, "w") as archive:
                 for local_path, relative_path in files:
+                    _remote_join_under_root(
+                        root=remote_pack_root,
+                        base=remote_workspace,
+                        relative_path=relative_path,
+                    )
                     archive.add(local_path, arcname=relative_path, recursive=False)
 
             ssh_pool.run(
-                f"mkdir -p {shlex.quote(remote_pack_root)} "
+                f"mkdir -p {shlex.quote(remote_workspace)} "
                 f"{shlex.quote(remote_project_dir)}"
             )
             ssh_pool.upload_file(str(archive_path), remote_archive)
 
         ssh_pool.run(
-            f"tar -xf {shlex.quote(remote_archive)} "
-            f"-C {shlex.quote(remote_project_dir)}"
+            f"tar -xf {shlex.quote(remote_archive)} -C {shlex.quote(remote_workspace)}"
         )
+        return remote_project_dir
 
     def _pack_environment_on_remote(
         self,
@@ -1674,10 +1694,10 @@ class SlurmPipesClient(PipesClient):
     ) -> str:
         """Run pixi-pack on the edge node and extract into the shared env cache."""
         token = f"{os.getpid()}.{uuid.uuid4().hex[:8]}"
-        remote_project_dir = f"{env_base_dir}/pack-work/{token}/project"
-        self._stage_remote_pack_workspace(
+        remote_pack_root = f"{env_base_dir}/pack-work/{token}"
+        remote_project_dir = self._stage_remote_pack_workspace(
             ssh_pool=ssh_pool,
-            remote_project_dir=remote_project_dir,
+            remote_pack_root=remote_pack_root,
             pack_cmds=[pack_cmd],
         )
 
@@ -1696,10 +1716,11 @@ class SlurmPipesClient(PipesClient):
         python_quoted = shlex.quote(python_bin)
         pack_script_quoted = f"{project_dir_quoted}/$pack_file"
 
+        pack_root_quoted = shlex.quote(remote_pack_root)
         inner = f"""
 set -euo pipefail
 if [ -f {activation_quoted} ] && [ -x {python_quoted} ]; then
-  rm -rf {shlex.quote(posixpath.dirname(remote_project_dir))}
+  rm -rf {pack_root_quoted}
   exit 0
 fi
 mkdir -p {env_dir_quoted}
@@ -1721,7 +1742,7 @@ case "$pack_file" in
     exit 1
     ;;
 esac
-rm -rf {shlex.quote(posixpath.dirname(remote_project_dir))}
+rm -rf {pack_root_quoted}
 """
         pack_cmd_remote = (
             f"mkdir -p {env_base_quoted} && "

--- a/projects/dagster-slurm/dagster_slurm_test/test_env_caching.py
+++ b/projects/dagster-slurm/dagster_slurm_test/test_env_caching.py
@@ -657,6 +657,9 @@ cmd = "pixi-pack --inject dist/base-*.whl pyproject.toml"
     fake_pixi.write_text(
         """#!/usr/bin/env bash
 set -euo pipefail
+test -f pyproject.toml
+test -f pixi.lock
+test -f dist/base-1.0.0-py3-none-any.whl
 cat > environment.sh <<'PACK'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -700,10 +703,8 @@ exec "$@"
     assert activation_script == str(env_base_dir / "activate.sh")
     assert (env_base_dir / "activate.sh").is_file()
     assert (env_dir / "bin" / "python").is_file()
-    staged_destinations = {Path(dest).name for _, dest in pool.uploads}
-    assert {"pyproject.toml", "pixi.lock", "base-1.0.0-py3-none-any.whl"} <= (
-        staged_destinations
-    )
+    assert len(pool.uploads) == 1
+    assert Path(pool.uploads[0][1]).name == "remote-pack-inputs.tar"
     assert not any(Path(src).name == "environment.sh" for src, _ in pool.uploads)
 
 

--- a/projects/dagster-slurm/dagster_slurm_test/test_env_caching.py
+++ b/projects/dagster-slurm/dagster_slurm_test/test_env_caching.py
@@ -374,10 +374,15 @@ def test_prepare_environment_remote_pack_does_not_upload_packed_env(
         lambda pack_cmd, env_overrides=None: "remote123",
     )
     monkeypatch.setattr(client, "_cached_env_ready", lambda **_: False)
+
+    def fake_stage_remote_pack_workspace(**kwargs):
+        captured["stage"] = kwargs
+        return f"{kwargs['remote_pack_root']}/workspace"
+
     monkeypatch.setattr(
         client,
         "_stage_remote_pack_workspace",
-        lambda **kwargs: captured.update({"stage": kwargs}),
+        fake_stage_remote_pack_workspace,
     )
     monkeypatch.setattr(
         "dagster_slurm.pipes_clients.slurm_pipes_client.pack_environment_with_pixi",
@@ -606,6 +611,48 @@ def test_remote_pack_input_files_rejects_matches_outside_workspace(
         )
 
 
+def test_remote_pack_input_files_uses_workspace_relative_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    slurm_client_factory: Callable[..., SlurmPipesClient],
+):
+    workspace = tmp_path / "workspace"
+    project_dir = workspace / "examples"
+    project_dir.mkdir(parents=True)
+    subprocess.run(
+        ["git", "init", "-q"], cwd=workspace, check=True, capture_output=True
+    )
+    (project_dir / "pyproject.toml").write_text(
+        """
+[tool.pixi.tasks.pack]
+cmd = "pixi-pack --inject ../dist/base-*.whl pyproject.toml"
+"""
+    )
+    (project_dir / "pixi.lock").write_text("lock")
+    dist = workspace / "dist"
+    dist.mkdir()
+    (dist / "base-1.0.0-py3-none-any.whl").write_text("wheel")
+    lib = workspace / "projects" / "lib" / "pkg"
+    lib.mkdir(parents=True)
+    (lib / "__init__.py").write_text("VALUE = 1\n")
+
+    monkeypatch.chdir(project_dir)
+    client = slurm_client_factory(cache_inject_globs=["../projects/lib/**/*.py"])
+
+    files = client._remote_pack_input_files(
+        [["pixi", "run", "--frozen", "pack"]], project_dir=project_dir
+    )
+
+    relative_paths = {relative for _, relative in files}
+    assert relative_paths == {
+        "examples/pyproject.toml",
+        "examples/pixi.lock",
+        "dist/base-1.0.0-py3-none-any.whl",
+        "projects/lib/pkg/__init__.py",
+    }
+    assert not any(".." in relative.split("/") for relative in relative_paths)
+
+
 def test_remote_pack_join_rejects_paths_outside_workspace():
     remote_root = "/remote/base/env-cache/key/pack-work/token"
     remote_project_dir = f"{remote_root}/project"
@@ -706,6 +753,94 @@ exec "$@"
     assert len(pool.uploads) == 1
     assert Path(pool.uploads[0][1]).name == "remote-pack-inputs.tar"
     assert not any(Path(src).name == "environment.sh" for src, _ in pool.uploads)
+
+
+def test_remote_pack_flow_supports_inputs_above_project_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    slurm_client_factory: Callable[..., SlurmPipesClient],
+):
+    workspace = tmp_path / "workspace"
+    project_dir = workspace / "examples"
+    project_dir.mkdir(parents=True)
+    subprocess.run(
+        ["git", "init", "-q"], cwd=workspace, check=True, capture_output=True
+    )
+    (project_dir / "pyproject.toml").write_text(
+        """
+[tool.pixi.tasks.pack-only]
+cmd = "pixi-pack --inject ../dist/base-*.whl pyproject.toml"
+""",
+        encoding="utf-8",
+    )
+    (project_dir / "pixi.lock").write_text("lock", encoding="utf-8")
+    dist = workspace / "dist"
+    dist.mkdir()
+    (dist / "base-1.0.0-py3-none-any.whl").write_text("wheel", encoding="utf-8")
+    lib = workspace / "projects" / "lib" / "pkg"
+    lib.mkdir(parents=True)
+    (lib / "__init__.py").write_text("VALUE = 1\n", encoding="utf-8")
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_pixi = fake_bin / "pixi"
+    fake_pixi.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+test -f pyproject.toml
+test -f pixi.lock
+test -f ../dist/base-1.0.0-py3-none-any.whl
+test -f ../projects/lib/pkg/__init__.py
+cat > environment.sh <<'PACK'
+#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p env/bin
+printf '#!/usr/bin/env bash\n' > env/bin/python
+chmod +x env/bin/python
+printf 'export PATH="$(pwd)/env/bin:$PATH"\n' > activate.sh
+PACK
+chmod +x environment.sh
+""",
+        encoding="utf-8",
+    )
+    fake_pixi.chmod(0o755)
+    fake_flock = fake_bin / "flock"
+    fake_flock.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+shift
+exec "$@"
+""",
+        encoding="utf-8",
+    )
+    fake_flock.chmod(0o755)
+
+    monkeypatch.chdir(project_dir)
+    monkeypatch.setenv("PATH", f"{fake_bin}{os.pathsep}{os.environ['PATH']}")
+
+    client = slurm_client_factory(
+        pack_on_remote=True,
+        remote_pack_timeout=10,
+        cache_inject_globs=["../projects/lib/**/*.py"],
+    )
+    pool = LocalShellPool()
+    env_base_dir = tmp_path / "remote" / "env-cache" / "remote123"
+    env_dir = env_base_dir / "env"
+
+    activation_script = client._pack_environment_on_remote(
+        ssh_pool=cast(Any, pool),
+        env_base_dir=str(env_base_dir),
+        env_dir=str(env_dir),
+        pack_cmd=["pixi", "run", "--frozen", "pack-only"],
+        env_overrides={"SLURM_PACK_PLATFORM": "linux-64"},
+    )
+
+    assert activation_script == str(env_base_dir / "activate.sh")
+    assert (env_base_dir / "activate.sh").is_file()
+    assert (env_dir / "bin" / "python").is_file()
+    assert not (env_base_dir / "pack-work").exists() or not any(
+        (env_base_dir / "pack-work").iterdir()
+    )
 
 
 def test_resolve_pack_platform_detects_apple_silicon_under_rosetta(


### PR DESCRIPTION
## Description

Stages remote pack input files as a single tar archive before extracting them on the Slurm edge node. This preserves the expected project-relative layout for pixi-pack inputs while reducing per-file upload handling.

## Motivation and Context

Remote environment packaging expects files such as pyproject.toml, pixi.lock, and wheel artifacts to be present in the correct relative locations. Uploading inputs individually could miss that layout; archiving and extracting the inputs keeps the staging step consistent.

## How Has This Been Tested?

Updated unit coverage to assert pixi-pack receives the expected staged inputs and that only the remote pack inputs archive is uploaded.

- [ ] Local development (mode: dev)
- [ ] Slurm staging environment
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

**Test Configuration**:

- Python version: Not specified
- Dagster version: Not specified
- OS: Not specified

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have updated the documentation accordingly
- [ ] I have added an entry to CHANGELOG.md
- [x] My commits follow the conventional commits format

## Screenshots (if appropriate)

N/A

## Additional Notes

No screenshots or migration steps required.

## Type of Change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] docs: Documentation
- [ ] style: Code style
- [ ] refactor: Code refactor
- [ ] perf: Performance improvement
- [ ] test: Tests
- [ ] chore: Maintenance

## Breaking Changes

BREAKING CHANGE: None