### PR TITLE
fix: release semantic release token

### DIFF
--- a/.github/workflows/library.yaml
+++ b/.github/workflows/library.yaml
@@ -532,6 +532,8 @@ jobs:
           git config --local user.name "GitHub Action"
 
       - name: Create release version
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
           set -e
 


### PR DESCRIPTION
## Summary
- pass the generated GitHub App token to the full-release semantic-release version step

## Validation
- pixi run -e build --frozen lint

Fixes the failed workflow_dispatch release job where semantic-release logged `Token value is missing!` and then failed with GitHub Releases 401.