### PR TITLE
fix: stop SSH log streams promptly

### DIFF
--- a/.github/workflows/library.yaml
+++ b/.github/workflows/library.yaml
@@ -427,8 +427,12 @@ jobs:
 
           pixi run -e build --frozen uv run semantic-release version --prerelease
 
-          if ! git diff --staged --quiet; then
-            git commit -m "chore: additional changes [skip ci]"
+          # semantic-release updates the workspace versions after dependency
+          # installation, so refresh the uv workspace metadata before pushing.
+          uv lock
+          git add uv.lock
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: update uv lockfile version [skip ci]"
           fi
 
       - name: Verify pre-release distributions
@@ -539,8 +543,12 @@ jobs:
 
           pixi run -e build --frozen uv run semantic-release version
 
-          if ! git diff --staged --quiet; then
-            git commit -m "chore: additional changes [skip ci]"
+          # Keep the lockfile's editable workspace versions in sync with the
+          # versions written by semantic-release.
+          uv lock
+          git add uv.lock
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: update uv lockfile version [skip ci]"
           fi
 
       - name: Verify release distributions

--- a/.gitignore
+++ b/.gitignore
@@ -1272,3 +1272,4 @@ slides/dist-multimodal/
 slides/dist-scipy2026/
 docs/static/slides-scipy2026/
 .devenv/
+examples/z_tmp/

--- a/examples/justfile
+++ b/examples/justfile
@@ -14,9 +14,10 @@ start-staging:
 start-prod-docker:
     pixi run -e dev --frozen start-prod-docker
 
-# Start dagster webserver in staging mode with real HPC
-start-staging-supercomputer:
-    pixi run -e dev --frozen start-staging-supercomputer
+# Start on port 3000 when available, otherwise let Dagster choose a free port.
+start-staging-supercomputer port="0":
+    mkdir -p "{{justfile_directory()}}/z_tmp/dagster_home"
+    DAGSTER_HOME="{{justfile_directory()}}/z_tmp/dagster_home" pixi run -e dev --frozen start-staging-supercomputer -- --port "{{port}}"
 
 # Start dagster webserver in production mode with real HPC (must pre-deploy!)
 start-production-supercomputer:

--- a/examples/projects/dagster-slurm-example/dagster_slurm_example/resources/__init__.py
+++ b/examples/projects/dagster-slurm-example/dagster_slurm_example/resources/__init__.py
@@ -260,13 +260,15 @@ SUPERCOMPUTER_SITE_OVERRIDES: Dict[str, Dict[str, Any]] = {
             "remote_pack_timeout": 1800,
         },
         "slurm_queue_config": {
-            "partition": "GPU-a100s",
+            # Keep the GRES request generic (gpu:1) so Slurm can place the job on
+            # whichever Datalab GPU partition becomes available first.
+            "partition": ("GPU-a100,GPU-a100s,GPU-a40,GPU-l40s,GPU-rtx6000"),
             "time_limit": "00:10:00",
             "num_nodes": 1,
             "gpus_per_node": 1,
         },
         "slurm_session_config": {
-            "partition": "GPU-a100s",
+            "partition": ("GPU-a100,GPU-a100s,GPU-a40,GPU-l40s,GPU-rtx6000"),
             "time_limit": "00:10:00",
             "num_nodes": 1,
             "gpus_per_node": 1,

--- a/projects/dagster-slurm/dagster_slurm/pipes_clients/slurm_pipes_client.py
+++ b/projects/dagster-slurm/dagster_slurm/pipes_clients/slurm_pipes_client.py
@@ -17,7 +17,7 @@ import time
 import uuid
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Protocol, TypeVar
 
 from dagster import (
     AssetExecutionContext,
@@ -52,6 +52,27 @@ _TAG_LAST_SUPERVISOR_HEARTBEAT = "dagster_slurm/last_supervisor_heartbeat"
 _TAG_ORPHAN_RECONCILED_AT = "dagster_slurm/orphan_reconciled_at"
 _TAG_ORPHAN_RETRY_OF = "dagster_slurm/orphan_retry_of"
 _HEARTBEAT_INTERVAL_SECONDS = 30.0
+
+
+class _TerminableProcess(Protocol):
+    """Process operations required by log-stream cleanup."""
+
+    def poll(self) -> Optional[int]: ...
+
+    def terminate(self) -> None: ...
+
+    def wait(self, timeout: Optional[float] = None) -> int: ...
+
+    def kill(self) -> None: ...
+
+
+class _JoinableThread(Protocol):
+    """Thread operation required by log-stream cleanup."""
+
+    def join(self, timeout: Optional[float] = None) -> None: ...
+
+
+_TerminableProcessT = TypeVar("_TerminableProcessT", bound=_TerminableProcess)
 
 
 def _remote_join_under_root(root: str, base: str, relative_path: str) -> str:
@@ -2455,6 +2476,8 @@ rm -rf {pack_root_quoted}
         stop_streaming = threading.Event()
         streamed_lines = {"stdout": 0, "stderr": 0}
         streamed_lock = threading.Lock()
+        stream_processes: dict[str, subprocess.Popen[str]] = {}
+        stream_processes_lock = threading.Lock()
 
         def stream_file(remote_path: str, output_stream, prefix: str, stream_key: str):
             try:
@@ -2497,17 +2520,22 @@ rm -rf {pack_root_quoted}
                         stop_streaming.wait(1.0)
                     return
 
-                proc = subprocess.Popen(
-                    tail_cmd,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.DEVNULL,
-                    text=True,
-                    bufsize=1,
-                )
-                if not proc.stdout:
-                    self.logger.warning(f"No stdout for {stream_key}")
-                    return
+                with stream_processes_lock:
+                    if stop_streaming.is_set():
+                        return
+                    proc = subprocess.Popen(
+                        tail_cmd,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.DEVNULL,
+                        text=True,
+                        bufsize=1,
+                    )
+                    stream_processes[stream_key] = proc
+
                 try:
+                    if not proc.stdout:
+                        self.logger.warning(f"No stdout for {stream_key}")
+                        return
                     while not stop_streaming.is_set():
                         line = proc.stdout.readline()
                         if not line:
@@ -2522,11 +2550,10 @@ rm -rf {pack_root_quoted}
                         with streamed_lock:
                             streamed_lines[stream_key] += 1
                 finally:
-                    proc.terminate()
-                    try:
-                        proc.wait(timeout=2)
-                    except:  # noqa: E722
-                        proc.kill()
+                    with stream_processes_lock:
+                        owns_process = stream_processes.pop(stream_key, None) is proc
+                    if owns_process:
+                        self._terminate_stream_processes({stream_key: proc})
             except Exception as e:
                 self.logger.warning(f"Error streaming {remote_path}: {e}")
 
@@ -2715,11 +2742,6 @@ rm -rf {pack_root_quoted}
                         # Give streaming threads time to catch up
                         self._interruptible_sleep(2, job_id)
 
-                        # Stop streaming and wait for threads to finish
-                        stop_streaming.set()
-                        stdout_thread.join(timeout=10)
-                        stderr_thread.join(timeout=10)
-
                         if state in {"CANCELLED", "PREEMPTED"}:
                             self.logger.warning(f"Job {job_id} was {state}")
                             self._cancellation_requested = True
@@ -2781,10 +2803,12 @@ rm -rf {pack_root_quoted}
                     raise
 
         finally:
-            # Stop streaming and clean up
-            stop_streaming.set()
-            stdout_thread.join(timeout=5)
-            stderr_thread.join(timeout=5)
+            self._stop_streaming_threads(
+                stop_streaming=stop_streaming,
+                stream_processes=stream_processes,
+                stream_processes_lock=stream_processes_lock,
+                stream_threads=(stdout_thread, stderr_thread),
+            )
             try:
                 existing = getattr(message_reader, "_streamed_lines", {})
                 if not isinstance(existing, dict):
@@ -2794,6 +2818,79 @@ rm -rf {pack_root_quoted}
                 setattr(message_reader, "_streamed_lines", existing)
             except Exception as exc:  # pragma: no cover - best effort bookkeeping
                 self.logger.debug(f"Failed to record streamed bytes: {exc}")
+
+    def _stop_streaming_threads(
+        self,
+        *,
+        stop_streaming: threading.Event,
+        stream_processes: dict[str, _TerminableProcessT],
+        stream_processes_lock: Any,
+        stream_threads: tuple[_JoinableThread, ...],
+    ) -> None:
+        """Terminate SSH tail processes before joining their reader threads."""
+        stop_streaming.set()
+        with stream_processes_lock:
+            processes = dict(stream_processes)
+            stream_processes.clear()
+
+        self._terminate_stream_processes(processes)
+
+        for thread in stream_threads:
+            thread.join(timeout=5)
+
+    def _terminate_stream_processes(
+        self,
+        processes: Mapping[str, _TerminableProcess],
+    ) -> None:
+        """Stop and reap SSH tail processes without masking the job outcome."""
+        for stream_key, proc in processes.items():
+            try:
+                if proc.poll() is not None:
+                    continue
+                try:
+                    proc.terminate()
+                except ProcessLookupError:
+                    pass
+            except OSError as exc:
+                self.logger.debug(
+                    "Could not terminate SSH %s log stream: %s",
+                    stream_key,
+                    exc,
+                )
+
+        for stream_key, proc in processes.items():
+            try:
+                proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                try:
+                    proc.kill()
+                except ProcessLookupError:
+                    pass
+                except OSError as exc:
+                    self.logger.debug(
+                        "Could not kill SSH %s log stream: %s",
+                        stream_key,
+                        exc,
+                    )
+                try:
+                    proc.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    self.logger.warning(
+                        "SSH %s log stream did not exit after being killed",
+                        stream_key,
+                    )
+                except OSError as exc:
+                    self.logger.debug(
+                        "Could not reap killed SSH %s log stream: %s",
+                        stream_key,
+                        exc,
+                    )
+            except OSError as exc:
+                self.logger.debug(
+                    "Could not reap SSH %s log stream: %s",
+                    stream_key,
+                    exc,
+                )
 
     def _build_tail_command(self, remote_path: str) -> Optional[list[str]]:
         """Build SSH tail command for streaming logs.

--- a/projects/dagster-slurm/dagster_slurm_test/conftest.py
+++ b/projects/dagster-slurm/dagster_slurm_test/conftest.py
@@ -11,6 +11,7 @@ import pytest
 from dagster_slurm import (
     ComputeResource,
     SlurmQueueConfig,
+    SlurmPipesClient,
     SlurmResource,
     SSHConnectionResource,
     BashLauncher,
@@ -89,18 +90,22 @@ def temp_dir():
 
 
 @pytest.fixture
-def mock_ssh_resource():
+def mock_ssh_resource(tmp_path: Path) -> SSHConnectionResource:
     """Mock SSH connection resource."""
+    key_path = tmp_path / "test_key"
+    key_path.touch()
     return SSHConnectionResource(
         host="localhost",
         port=2223,
         user="testuser",
-        key_path="/tmp/test_key",
+        key_path=str(key_path),
     )
 
 
 @pytest.fixture
-def mock_slurm_resource(mock_ssh_resource):
+def mock_slurm_resource(
+    mock_ssh_resource: SSHConnectionResource,
+) -> SlurmResource:
     """Mock Slurm resource."""
     return SlurmResource(
         ssh=mock_ssh_resource,
@@ -111,6 +116,17 @@ def mock_slurm_resource(mock_ssh_resource):
             mem="1G",
         ),
         remote_base="/tmp/dagster_test",
+    )
+
+
+@pytest.fixture
+def slurm_pipes_client(
+    mock_slurm_resource: SlurmResource,
+) -> SlurmPipesClient:
+    """Build a Slurm Pipes client with shared mock resources."""
+    return SlurmPipesClient(
+        slurm_resource=mock_slurm_resource,
+        launcher=BashLauncher(),
     )
 
 

--- a/projects/dagster-slurm/dagster_slurm_test/test_poll_timeout.py
+++ b/projects/dagster-slurm/dagster_slurm_test/test_poll_timeout.py
@@ -6,6 +6,7 @@ ComputeResource.run() -> SlurmPipesClient.run() -> _execute_standalone()
 """
 
 import inspect
+import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -13,40 +14,10 @@ import pytest
 from dagster import AssetKey
 from dagster._core.errors import DagsterPipesExecutionError
 
-from dagster_slurm import (
-    BashLauncher,
-    ComputeResource,
-    SlurmResource,
-    SSHConnectionResource,
-    SlurmQueueConfig,
-)
+from dagster_slurm import ComputeResource
 from dagster_slurm.config.environment import ExecutionMode
 from dagster_slurm.helpers import SlurmJobMetrics
 from dagster_slurm.pipes_clients.slurm_pipes_client import SlurmPipesClient
-
-
-def _make_client() -> SlurmPipesClient:
-    ssh = SSHConnectionResource(
-        host="localhost",
-        port=2223,
-        user="testuser",
-        password="testpass",
-    )
-    slurm = SlurmResource(
-        ssh=ssh,
-        queue=SlurmQueueConfig(
-            partition="test",
-            time_limit="00:10:00",
-            cpus=2,
-            mem="1G",
-        ),
-        remote_base="/tmp/dagster_test",
-    )
-    return SlurmPipesClient(
-        slurm_resource=slurm,
-        launcher=BashLauncher(),
-    )
-
 
 # ---------------------------------------------------------------------------
 # Signature tests — verify the parameter exists with correct defaults
@@ -78,19 +49,25 @@ def test_wait_for_job_default_poll_timeout():
 # ---------------------------------------------------------------------------
 
 
-def test_execute_standalone_forwards_poll_timeout():
+def test_execute_standalone_forwards_poll_timeout(
+    slurm_pipes_client: SlurmPipesClient,
+):
     """_execute_standalone passes poll_timeout to _wait_for_job_with_streaming."""
-    client = _make_client()
-
     mock_ssh_pool = MagicMock()
     mock_ssh_pool.run.return_value = "Submitted batch job 12345"
 
     with (
-        patch.object(client, "_wait_for_job_with_streaming") as mock_wait,
-        patch.object(client, "_store_job_tags"),
-        patch.object(client, "_log_estimated_start_time"),
-        patch.object(client, "_get_asset_key_string", return_value="test_asset"),
-        patch.object(client, "_build_sbatch_command", return_value="sbatch job.sh"),
+        patch.object(slurm_pipes_client, "_wait_for_job_with_streaming") as mock_wait,
+        patch.object(slurm_pipes_client, "_store_job_tags"),
+        patch.object(slurm_pipes_client, "_log_estimated_start_time"),
+        patch.object(
+            slurm_pipes_client, "_get_asset_key_string", return_value="test_asset"
+        ),
+        patch.object(
+            slurm_pipes_client,
+            "_build_sbatch_command",
+            return_value="sbatch job.sh",
+        ),
     ):
         # Mock the script writing/upload portion
         mock_execution_plan = MagicMock()
@@ -98,7 +75,7 @@ def test_execute_standalone_forwards_poll_timeout():
         mock_execution_plan.resources = {}
         mock_execution_plan.kind = "bash"
 
-        client._execute_standalone(
+        slurm_pipes_client._execute_standalone(
             execution_plan=mock_execution_plan,
             run_dir="/tmp/test_run",
             ssh_pool=mock_ssh_pool,
@@ -111,26 +88,32 @@ def test_execute_standalone_forwards_poll_timeout():
         assert kwargs["poll_timeout"] == 7200
 
 
-def test_execute_standalone_uses_default_poll_timeout():
+def test_execute_standalone_uses_default_poll_timeout(
+    slurm_pipes_client: SlurmPipesClient,
+):
     """_execute_standalone uses default 3600s when poll_timeout not specified."""
-    client = _make_client()
-
     mock_ssh_pool = MagicMock()
     mock_ssh_pool.run.return_value = "Submitted batch job 12345"
 
     with (
-        patch.object(client, "_wait_for_job_with_streaming") as mock_wait,
-        patch.object(client, "_store_job_tags"),
-        patch.object(client, "_log_estimated_start_time"),
-        patch.object(client, "_get_asset_key_string", return_value="test_asset"),
-        patch.object(client, "_build_sbatch_command", return_value="sbatch job.sh"),
+        patch.object(slurm_pipes_client, "_wait_for_job_with_streaming") as mock_wait,
+        patch.object(slurm_pipes_client, "_store_job_tags"),
+        patch.object(slurm_pipes_client, "_log_estimated_start_time"),
+        patch.object(
+            slurm_pipes_client, "_get_asset_key_string", return_value="test_asset"
+        ),
+        patch.object(
+            slurm_pipes_client,
+            "_build_sbatch_command",
+            return_value="sbatch job.sh",
+        ),
     ):
         mock_execution_plan = MagicMock()
         mock_execution_plan.payload = ["#!/bin/bash", "echo hello"]
         mock_execution_plan.resources = {}
         mock_execution_plan.kind = "bash"
 
-        client._execute_standalone(
+        slurm_pipes_client._execute_standalone(
             execution_plan=mock_execution_plan,
             run_dir="/tmp/test_run",
             ssh_pool=mock_ssh_pool,
@@ -142,10 +125,10 @@ def test_execute_standalone_uses_default_poll_timeout():
         assert kwargs["poll_timeout"] == 3600
 
 
-def test_reattach_path_forwards_poll_timeout():
+def test_reattach_path_forwards_poll_timeout(
+    slurm_pipes_client: SlurmPipesClient,
+):
     """The reattach code path in run() also forwards poll_timeout."""
-    client = _make_client()
-
     # Build a mock context that satisfies the run() method
     mock_context = MagicMock()
     mock_context.run.run_id = "test-run-id"
@@ -156,16 +139,26 @@ def test_reattach_path_forwards_poll_timeout():
     reattach_info = {"job_id": "42", "run_dir": "/tmp/old_run"}
 
     with (
-        patch.object(client, "_wait_for_job_with_streaming") as mock_wait,
-        patch.object(client, "_execute_standalone") as mock_standalone,
-        patch.object(client, "_find_reattachable_job", return_value=reattach_info),
-        patch.object(client, "_is_job_still_running", return_value=True),
-        patch.object(client, "_get_job_state", return_value="RUNNING"),
-        patch.object(client, "_get_asset_key_string", return_value="test_asset"),
-        patch.object(client, "_store_job_tags"),
-        patch.object(client, "_maybe_emit_final_logs"),
-        patch.object(client, "_collect_and_emit_metrics"),
-        patch.object(client, "_get_remote_base", return_value="/tmp/dagster_test"),
+        patch.object(slurm_pipes_client, "_wait_for_job_with_streaming") as mock_wait,
+        patch.object(slurm_pipes_client, "_execute_standalone") as mock_standalone,
+        patch.object(
+            slurm_pipes_client,
+            "_find_reattachable_job",
+            return_value=reattach_info,
+        ),
+        patch.object(slurm_pipes_client, "_is_job_still_running", return_value=True),
+        patch.object(slurm_pipes_client, "_get_job_state", return_value="RUNNING"),
+        patch.object(
+            slurm_pipes_client, "_get_asset_key_string", return_value="test_asset"
+        ),
+        patch.object(slurm_pipes_client, "_store_job_tags"),
+        patch.object(slurm_pipes_client, "_maybe_emit_final_logs"),
+        patch.object(slurm_pipes_client, "_collect_and_emit_metrics"),
+        patch.object(
+            slurm_pipes_client,
+            "_get_remote_base",
+            return_value="/tmp/dagster_test",
+        ),
         patch(
             "dagster_slurm.pipes_clients.slurm_pipes_client.SSHConnectionPool"
         ) as MockSSHPool,
@@ -183,7 +176,7 @@ def test_reattach_path_forwards_poll_timeout():
         mock_open_pipes.return_value.__enter__ = MagicMock(return_value=mock_session)
         mock_open_pipes.return_value.__exit__ = MagicMock(return_value=False)
 
-        client.run(
+        slurm_pipes_client.run(
             context=mock_context,
             payload_path="test_payload.py",
             poll_timeout=14400,
@@ -198,16 +191,16 @@ def test_reattach_path_forwards_poll_timeout():
         assert kwargs["poll_timeout"] == 14400
 
 
-def test_wait_for_job_respects_custom_poll_timeout():
+def test_wait_for_job_respects_custom_poll_timeout(
+    slurm_pipes_client: SlurmPipesClient,
+):
     """_wait_for_job_with_streaming times out based on poll_timeout value."""
-    client = _make_client()
-
     mock_ssh_pool = MagicMock()
     # Simulate a job that is always PENDING (never completes)
     mock_ssh_pool.run.return_value = "PENDING"
 
     with pytest.raises(RuntimeError, match=r"Timed out after 1s"):
-        client._wait_for_job_with_streaming(
+        slurm_pipes_client._wait_for_job_with_streaming(
             job_id=99999,
             ssh_pool=mock_ssh_pool,
             run_dir="/tmp/test_run",
@@ -216,27 +209,129 @@ def test_wait_for_job_respects_custom_poll_timeout():
         )
 
 
-def test_get_job_state_normalizes_truncated_terminal_state():
+def test_stream_cleanup_terminates_tail_processes_before_single_join(
+    slurm_pipes_client: SlurmPipesClient,
+):
+    """Blocked tail readers should stop promptly and be joined only once."""
+    events = []
+
+    class BlockingTailProcess:
+        def __init__(self, stream_key):
+            self.stream_key = stream_key
+            self.released = threading.Event()
+            self.stdout = SimpleNamespace(readline=self._readline)
+            self.returncode = None
+            self.terminate_calls = 0
+
+        def _readline(self):
+            self.released.wait(timeout=5)
+            return ""
+
+        def poll(self):
+            return self.returncode
+
+        def terminate(self):
+            self.terminate_calls += 1
+            events.append(f"terminate:{self.stream_key}")
+            self.returncode = -15
+            self.released.set()
+
+        def wait(self, timeout=None):
+            if not self.released.wait(timeout=timeout):
+                raise TimeoutError
+            return self.returncode
+
+        def kill(self):
+            self.returncode = -9
+            self.released.set()
+
+    class RecordingThread:
+        def __init__(self, stream_key, process):
+            self.stream_key = stream_key
+            self._thread = threading.Thread(target=process.stdout.readline)
+            self.join_calls = 0
+            self._thread.start()
+
+        def join(self, timeout=None):
+            self.join_calls += 1
+            events.append(f"join:{self.stream_key}")
+            self._thread.join(timeout=timeout)
+
+        def is_alive(self):
+            return self._thread.is_alive()
+
+    stdout_process = BlockingTailProcess("stdout")
+    stderr_process = BlockingTailProcess("stderr")
+    stdout_thread = RecordingThread("stdout", stdout_process)
+    stderr_thread = RecordingThread("stderr", stderr_process)
+    stop_streaming = threading.Event()
+    stream_processes = {
+        "stdout": stdout_process,
+        "stderr": stderr_process,
+    }
+
+    slurm_pipes_client._stop_streaming_threads(
+        stop_streaming=stop_streaming,
+        stream_processes=stream_processes,
+        stream_processes_lock=threading.Lock(),
+        stream_threads=(stdout_thread, stderr_thread),
+    )
+
+    assert stop_streaming.is_set()
+    assert stdout_process.terminate_calls == 1
+    assert stderr_process.terminate_calls == 1
+    assert stream_processes == {}
+    assert events[:2] == ["terminate:stdout", "terminate:stderr"]
+    assert stdout_thread.join_calls == 1
+    assert stderr_thread.join_calls == 1
+    assert not stdout_thread.is_alive()
+    assert not stderr_thread.is_alive()
+
+
+def test_stream_cleanup_does_not_raise_for_process_errors(
+    slurm_pipes_client: SlurmPipesClient,
+):
+    """Tail cleanup failures should not mask the Slurm job outcome."""
+    process = MagicMock()
+    process.poll.side_effect = OSError("process disappeared")
+    process.wait.side_effect = OSError("process disappeared")
+    thread = MagicMock()
+    stream_processes = {"stdout": process}
+
+    slurm_pipes_client._stop_streaming_threads(
+        stop_streaming=threading.Event(),
+        stream_processes=stream_processes,
+        stream_processes_lock=threading.Lock(),
+        stream_threads=(thread,),
+    )
+
+    assert stream_processes == {}
+    thread.join.assert_called_once_with(timeout=5)
+
+
+def test_get_job_state_normalizes_truncated_terminal_state(
+    slurm_pipes_client: SlurmPipesClient,
+):
     """sacct state truncation should still resolve to a terminal state."""
-    client = _make_client()
     mock_ssh_pool = MagicMock()
     mock_ssh_pool.run.side_effect = ["", "OUT_OF_ME+\n"]
 
-    state = client._get_job_state(12345, mock_ssh_pool)
+    state = slurm_pipes_client._get_job_state(12345, mock_ssh_pool)
 
     assert state == "OUT_OF_MEMORY"
 
 
-def test_validate_final_slurm_outcome_rejects_failed_batch_state():
+def test_validate_final_slurm_outcome_rejects_failed_batch_state(
+    slurm_pipes_client: SlurmPipesClient,
+):
     """Final sacct validation must reject batch-step failures after a transient success."""
-    client = _make_client()
     mock_ssh_pool = MagicMock()
     mock_ssh_pool.run.return_value = (
         "12345|TIMEOUT|0:0\n12345.batch|OUT_OF_ME+|0:125\n12345.extern|COMPLETED|0:0\n"
     )
 
     with patch.object(
-        client.metrics_collector,
+        slurm_pipes_client.metrics_collector,
         "collect_job_metrics",
         return_value=SlurmJobMetrics(
             job_id=12345,
@@ -250,12 +345,13 @@ def test_validate_final_slurm_outcome_rejects_failed_batch_state():
         ),
     ):
         with pytest.raises(RuntimeError, match=r"12345 did not complete successfully"):
-            client._validate_final_slurm_outcome(12345, mock_ssh_pool)
+            slurm_pipes_client._validate_final_slurm_outcome(12345, mock_ssh_pool)
 
 
-def test_validate_final_slurm_outcome_accepts_clean_completed_job():
+def test_validate_final_slurm_outcome_accepts_clean_completed_job(
+    slurm_pipes_client: SlurmPipesClient,
+):
     """Final sacct validation should accept clean parent and batch completion."""
-    client = _make_client()
     mock_ssh_pool = MagicMock()
     mock_ssh_pool.run.return_value = (
         "12345|COMPLETED|0:0\n12345.batch|COMPLETED|0:0\n12345.extern|COMPLETED|0:0\n"
@@ -272,17 +368,20 @@ def test_validate_final_slurm_outcome_accepts_clean_completed_job():
     )
 
     with patch.object(
-        client.metrics_collector,
+        slurm_pipes_client.metrics_collector,
         "collect_job_metrics",
         return_value=expected_metrics,
     ):
-        actual_metrics = client._validate_final_slurm_outcome(12345, mock_ssh_pool)
+        actual_metrics = slurm_pipes_client._validate_final_slurm_outcome(
+            12345, mock_ssh_pool
+        )
 
     assert actual_metrics == expected_metrics
 
 
-def test_raise_if_pipes_process_failed_raises():
-    client = _make_client()
+def test_raise_if_pipes_process_failed_raises(
+    slurm_pipes_client: SlurmPipesClient,
+):
     message_reader = SimpleNamespace(
         closed_exception={
             "name": "RuntimeError",
@@ -294,7 +393,7 @@ def test_raise_if_pipes_process_failed_raises():
         DagsterPipesExecutionError,
         match="RuntimeError: remote boom",
     ):
-        client._raise_if_pipes_process_failed(message_reader, job_id=12345)
+        slurm_pipes_client._raise_if_pipes_process_failed(message_reader, job_id=12345)
 
 
 # ---------------------------------------------------------------------------
@@ -313,19 +412,15 @@ class _RecordingClient(SlurmPipesClient):
         return SimpleNamespace()
 
 
-def test_compute_resource_forwards_poll_timeout(monkeypatch):
+def test_compute_resource_forwards_poll_timeout(
+    monkeypatch,
+    slurm_pipes_client: SlurmPipesClient,
+):
     """ComputeResource.run() forwards poll_timeout to client.run() via kwargs."""
-    slurm = SlurmResource(
-        ssh=SSHConnectionResource(
-            host="localhost", port=2222, user="test", password="secret"
-        ),
-        queue=SlurmQueueConfig(),
-        remote_base="/tmp/dagster_test",
-    )
     resource = ComputeResource(
         mode=ExecutionMode.SLURM,
-        slurm=slurm,
-        default_launcher=BashLauncher(),
+        slurm=slurm_pipes_client.slurm,
+        default_launcher=slurm_pipes_client.launcher,
     )
 
     fake_client = _RecordingClient()


### PR DESCRIPTION
## Summary

- track active SSH tail -F subprocesses and terminate them before joining reader threads
- join each streaming thread exactly once and keep cleanup failures from masking the Slurm job outcome
- reuse the shared Slurm test fixture and cover blocked readers plus process-cleanup failures

## Why

After Slurm reported completion, both reader threads could remain blocked in readline while the monitor joined them twice with long timeouts. This added roughly 35 seconds before Dagster observed the successful result.

## Testing

- 55 focused polling, reattach, cancellation, and message-reader tests passed; 3 Docker-only tests deselected
- Ruff check and formatting passed for all changed files
- targeted ty type check passed