### PR TITLE
feat: project setup release notes

### DIFF
--- a/docs/docs/how-to/environment-packaging.md
+++ b/docs/docs/how-to/environment-packaging.md
@@ -51,6 +51,10 @@ compute = ComputeResource(
 | `cache_inject_globs`          | `None`  | Glob patterns for inject files that affect cache key. If not set, all inject files are hashed.                       |
 | `pack_on_remote`              | `False` | When `True`, run packaging on the Slurm edge node on cache misses and upload only small pack inputs.                 |
 | `remote_pack_timeout`         | `600`   | Timeout in seconds for remote packaging and extraction.                                                              |
+| `project_setup_cmd`           | `None`  | Project-level edge-node command that prepares multiple named environments in one cache entry.                        |
+| `project_setup_env`           | `{}`    | Environment variables passed to the project setup command.                                                           |
+| `project_setup_input_globs`   | `None`  | Additional project-relative inputs staged for the setup command.                                                     |
+| `default_environment_name`    | `None`  | Default named environment selected from project setup output.                                                        |
 | `auto_detect_platform`        | `False` | Auto-detect target platform from edge node architecture.                                                             |
 | `pack_platform`               | `None`  | Explicit target platform (e.g., `linux-64`).                                                                         |
 | `debug_mode`                  | `False` | Keep build artefacts for inspection.                                                                                 |
@@ -133,6 +137,86 @@ If the remote pack step fails, `dagster-slurm` falls back to local packaging and
 For the example supercomputer configuration, `SLURM_PACK_ON_REMOTE` defaults to enabled and can be disabled with `SLURM_PACK_ON_REMOTE=false`.
 Use `SLURM_REMOTE_PACK_TIMEOUT` to tune the remote timeout.
 
+## Multi-environment project setup
+
+Use `project_setup_cmd` when one project command prepares a coordinated set of environments instead of one `pixi-pack` archive.
+The command runs on a cache miss or forced refresh from a durable staged project directory on the Slurm edge node.
+Pixi manifests, `pixi.lock`, and `justfile`/`Justfile` are staged automatically; use `project_setup_input_globs` for scripts, local packages, or other required inputs.
+
+```python
+compute = ComputeResource(
+    mode="slurm",
+    slurm=slurm_resource,
+    default_launcher=BashLauncher(),
+    project_setup_cmd=["just", "setup-gpu"],
+    project_setup_env={
+        "MODEL_CACHE": "/share/models",
+    },
+    project_setup_input_globs=[
+        "scripts/setup-*.sh",
+        "projects/shared/**/*.py",
+    ],
+    default_environment_name="cpu",
+    remote_pack_timeout=1800,
+)
+```
+
+The setup command receives these additional variables:
+
+| Variable                           | Purpose                                                         |
+| ---------------------------------- | --------------------------------------------------------------- |
+| `DAGSTER_SLURM_REMOTE_PROJECT_DIR` | Durable staged project directory and command working directory. |
+| `DAGSTER_SLURM_ENV_BASE_DIR`       | Stable cache entry below `{remote_base}/env-cache/<key>`.       |
+| `SLURM_PACK_PLATFORM`              | Resolved target platform, such as `linux-64`.                   |
+
+An ordinary multi-environment Pixi setup can install environments into `.pixi/envs`:
+
+```just title="justfile"
+setup-gpu:
+    pixi install --locked --environment cpu
+    pixi install --locked --environment gpu
+```
+
+After the command succeeds, every executable `.pixi/envs/<name>/bin/python` is published under `{env_base_dir}/envs/<name>/bin/python`.
+An existing `.pixi/envs/<name>/activate.sh` is preserved; otherwise dagster-slurm generates one with `pixi shell-hook --shell bash -e <name>` so Pixi activation variables and scripts are retained.
+Publication happens under the existing remote-pack lock, and the shared `envs` link is replaced atomically.
+A failed or timed-out setup blocks job submission and does not fall back to another environment.
+Set `force_env_push=True` to rerun the setup command and atomically refresh every named environment even when the cache is already populated.
+
+Select an environment explicitly, through launchpad configuration, or with asset metadata:
+
+```python
+@dg.asset(metadata={"slurm_environment_name": "gpu"})
+def gpu_training(context: dg.AssetExecutionContext, compute: ComputeResource):
+    return compute.run(
+        context=context,
+        payload_path="train.py",
+    ).get_results()
+
+
+@dg.asset
+def cpu_inference(context: dg.AssetExecutionContext, compute: ComputeResource):
+    return compute.run(
+        context=context,
+        payload_path="infer.py",
+        environment_name="cpu",
+    ).get_results()
+```
+
+`SlurmRunConfig.environment_name` provides the same selection in the Dagster launchpad.
+Selection precedence is the explicit `compute.run()` argument, `SlurmRunConfig`, `slurm_environment_name` metadata, then `default_environment_name`.
+All selections share one setup cache because the environment name is not part of its cache key.
+
+### Shared storage and scratch
+
+The cache remains below `SlurmResource.remote_base`; no second durable storage root is introduced.
+Choose a shared filesystem such as `/home` or `/share` according to site policy, and point model or tool caches at shared locations through `project_setup_env`.
+For example, a group installation can use `remote_base="/share/group/dagster-runs"` and `MODEL_CACHE="/share/models"`.
+
+Node-local `/scratch` can improve runtime I/O, but it is not a durable project setup destination.
+If needed, copy selected files to `/scratch` from inside the Slurm allocation and copy durable results back to shared storage.
+An edge-node setup must not assume that its `/scratch` path is local to every compute node.
+
 ## Runtime configuration with SlurmRunConfig
 
 Use `SlurmRunConfig` to make environment and payload settings configurable at job submission time via the Dagster launchpad.
@@ -162,6 +246,7 @@ def my_asset(
 | `force_env_push`      | `False` | Force re-pack and upload the environment even when cached. Useful after manual changes to injected packages. |
 | `skip_payload_upload` | `False` | Skip uploading the payload script. Use when the script already exists on the remote.                         |
 | `remote_payload_path` | `None`  | Custom remote path for the payload when `skip_payload_upload=True`.                                          |
+| `environment_name`    | `None`  | Select one environment produced by `project_setup_cmd`.                                                      |
 
 ### When to use SlurmRunConfig
 

--- a/projects/dagster-slurm/dagster_slurm/config/runtime.py
+++ b/projects/dagster-slurm/dagster_slurm/config/runtime.py
@@ -67,6 +67,14 @@ class SlurmRunConfig(dg.Config):
         ),
     )
 
+    environment_name: Optional[str] = Field(
+        default=None,
+        description=(
+            "Named environment produced by ComputeResource.project_setup_cmd. "
+            "Overrides asset metadata and the resource default."
+        ),
+    )
+
     extra_files: Optional[List[str]] = Field(
         default=None,
         description=(

--- a/projects/dagster-slurm/dagster_slurm/pipes_clients/slurm_pipes_client.py
+++ b/projects/dagster-slurm/dagster_slurm/pipes_clients/slurm_pipes_client.py
@@ -135,6 +135,9 @@ class SlurmPipesClient(PipesClient):
         cache_inject_globs: Optional[list[str]] = None,
         pack_on_remote: bool = False,
         remote_pack_timeout: int = 600,
+        project_setup_cmd: Optional[list[str]] = None,
+        project_setup_env: Optional[dict[str, str]] = None,
+        project_setup_input_globs: Optional[list[str]] = None,
         run_allocation_scope: bool = False,
     ):
         """Args:
@@ -152,6 +155,11 @@ class SlurmPipesClient(PipesClient):
         pack_on_remote: If True, stage small pack inputs on the edge node and run
             pixi-pack there instead of uploading the self-extracting environment.
         remote_pack_timeout: Timeout in seconds for the remote pack and extract step.
+        project_setup_cmd: Optional command that prepares multiple named environments
+            from a staged project on the edge node.
+        project_setup_env: Environment variables passed to ``project_setup_cmd``.
+        project_setup_input_globs: Additional project-relative files to stage for the
+            setup command.
 
         """
         super().__init__()
@@ -174,6 +182,9 @@ class SlurmPipesClient(PipesClient):
         self.cache_inject_globs = cache_inject_globs
         self.pack_on_remote = pack_on_remote
         self.remote_pack_timeout = remote_pack_timeout
+        self.project_setup_cmd = project_setup_cmd
+        self.project_setup_env = project_setup_env or {}
+        self.project_setup_input_globs = project_setup_input_globs or []
         self.run_allocation_scope = run_allocation_scope
 
     def run(  # ty: ignore[invalid-method-override]  # Dagster PipesClient is designed for extension
@@ -190,6 +201,7 @@ class SlurmPipesClient(PipesClient):
         remote_payload_path: Optional[str] = None,
         pack_cmd_override: Optional[list[str]] = None,
         pre_deployed_env_path_override: Optional[str] = None,
+        environment_name: Optional[str] = None,
         extra_files: Optional[list[str]] = None,
         poll_timeout: int = 3600,
         **kwargs,
@@ -210,6 +222,7 @@ class SlurmPipesClient(PipesClient):
                 it already exists remotely).
             remote_payload_path: Optional pre-existing remote payload path to use when
                 skipping upload.
+            environment_name: Named environment prepared by ``project_setup_cmd``.
             poll_timeout: Maximum time in seconds to wait for the Slurm job to
                 complete. Defaults to 3600 (1 hour).
             **kwargs: Additional arguments (ignored, for forward compatibility)
@@ -445,6 +458,7 @@ class SlurmPipesClient(PipesClient):
                     force_env_push=force_env_push,
                     pack_cmd_override=pack_cmd_override,
                     pre_deployed_env_path_override=pre_deployed_env_path_override,
+                    environment_name=environment_name,
                 )
 
                 # Check for cancellation – only abort on user-initiated cancel
@@ -1574,7 +1588,10 @@ class SlurmPipesClient(PipesClient):
         return None
 
     def _remote_pack_input_files(
-        self, pack_cmds: list[list[str]], project_dir: Path
+        self,
+        pack_cmds: list[list[str]],
+        project_dir: Path,
+        extra_input_globs: Optional[list[str]] = None,
     ) -> list[tuple[Path, str]]:
         """Return local files to stage for remote packing.
 
@@ -1603,7 +1620,13 @@ class SlurmPipesClient(PipesClient):
                 ) from exc
             files[relative.as_posix()] = resolved
 
-        for name in ("pyproject.toml", "pixi.toml", "pixi.lock"):
+        for name in (
+            "pyproject.toml",
+            "pixi.toml",
+            "pixi.lock",
+            "justfile",
+            "Justfile",
+        ):
             add_file(project_dir / name)
 
         patterns: list[str] = []
@@ -1622,6 +1645,8 @@ class SlurmPipesClient(PipesClient):
 
         if self.cache_inject_globs:
             patterns.extend(self.cache_inject_globs)
+        if extra_input_globs:
+            patterns.extend(extra_input_globs)
 
         missing_patterns: list[str] = []
         for pattern in patterns:
@@ -1651,6 +1676,7 @@ class SlurmPipesClient(PipesClient):
         ssh_pool: SSHConnectionPool,
         remote_pack_root: str,
         pack_cmds: list[list[str]],
+        extra_input_globs: Optional[list[str]] = None,
     ) -> str:
         """Upload the small set of files needed to run pixi-pack remotely.
 
@@ -1661,7 +1687,11 @@ class SlurmPipesClient(PipesClient):
         """
         project_dir = Path.cwd()
         workspace_root = _local_pack_workspace_root(project_dir)
-        files = self._remote_pack_input_files(pack_cmds, project_dir=project_dir)
+        files = self._remote_pack_input_files(
+            pack_cmds,
+            project_dir=project_dir,
+            extra_input_globs=extra_input_globs,
+        )
         if not files:
             raise RuntimeError("Remote packing could not find any local pack inputs")
 
@@ -1704,6 +1734,193 @@ class SlurmPipesClient(PipesClient):
             f"tar -xf {shlex.quote(remote_archive)} -C {shlex.quote(remote_workspace)}"
         )
         return remote_project_dir
+
+    @staticmethod
+    def _validate_environment_name(environment_name: str) -> str:
+        """Validate a named environment used below the shared cache root."""
+        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", environment_name):
+            raise ValueError(
+                "environment_name must contain only letters, numbers, '.', '_', "
+                f"or '-', and must start with a letter or number: {environment_name!r}"
+            )
+        return environment_name
+
+    @staticmethod
+    def _validate_environment_variables(environment: Mapping[str, str]) -> None:
+        """Reject environment keys that cannot be assigned safely by Bash."""
+        invalid_keys = [
+            key
+            for key in environment
+            if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", key)
+        ]
+        if invalid_keys:
+            raise ValueError(
+                "project_setup_env contains invalid environment variable name(s): "
+                + ", ".join(sorted(invalid_keys))
+            )
+
+    def _compute_project_setup_cache_key(
+        self,
+        setup_cmd: list[str],
+        env_overrides: dict[str, str],
+    ) -> str:
+        """Hash the setup command, environment, and every staged project input."""
+        project_dir = Path.cwd()
+        files = self._remote_pack_input_files(
+            [setup_cmd],
+            project_dir=project_dir,
+            extra_input_globs=self.project_setup_input_globs,
+        )
+        if not files:
+            raise RuntimeError(
+                "Project setup could not find any inputs to stage. Add a Pixi "
+                "manifest or configure project_setup_input_globs."
+            )
+
+        digest = hashlib.sha256()
+        digest.update(b"dagster-slurm-project-setup-v2\0")
+        for arg in setup_cmd:
+            digest.update(arg.encode())
+            digest.update(b"\0")
+        for key, value in sorted(env_overrides.items()):
+            digest.update(key.encode())
+            digest.update(b"=")
+            digest.update(value.encode())
+            digest.update(b"\0")
+        for path, relative_path in files:
+            digest.update(relative_path.encode())
+            digest.update(b"\0")
+            digest.update(path.read_bytes())
+            digest.update(b"\0")
+        return digest.hexdigest()[:16]
+
+    def _setup_project_environments_on_remote(
+        self,
+        ssh_pool: SSHConnectionPool,
+        env_base_dir: str,
+        setup_cmd: list[str],
+        environment_name: str,
+        env_overrides: dict[str, str],
+        force_refresh: bool = False,
+    ) -> tuple[str, str]:
+        """Prepare and atomically publish named environments on the edge node."""
+        environment_name = self._validate_environment_name(environment_name)
+        token = f"{os.getpid()}.{uuid.uuid4().hex[:8]}"
+        remote_pack_root = f"{env_base_dir}/pack-work/{token}"
+        staged_project_dir = self._stage_remote_pack_workspace(
+            ssh_pool=ssh_pool,
+            remote_pack_root=remote_pack_root,
+            pack_cmds=[setup_cmd],
+            extra_input_globs=self.project_setup_input_globs,
+        )
+
+        output_root = f"{env_base_dir}/setup-output/{token}"
+        setup_project_dir = f"{output_root}/project"
+        project_envs_dir = f"{setup_project_dir}/.pixi/envs"
+        published_envs_dir = f"{env_base_dir}/envs"
+        activation_script = f"{published_envs_dir}/{environment_name}/activate.sh"
+        python_executable = f"{published_envs_dir}/{environment_name}/bin/python"
+        lock_file = f"{env_base_dir}/.remote-pack.lock"
+        temporary_link = f"{env_base_dir}/.envs.{token}.tmp"
+
+        command_env = {
+            **self.project_setup_env,
+            **env_overrides,
+            "DAGSTER_SLURM_ENV_BASE_DIR": env_base_dir,
+            "DAGSTER_SLURM_REMOTE_PROJECT_DIR": setup_project_dir,
+        }
+        self._validate_environment_variables(command_env)
+        env_prefix = " ".join(
+            f"{key}={shlex.quote(value)}" for key, value in sorted(command_env.items())
+        )
+        command = f"{env_prefix} {shlex.join(setup_cmd)}".strip()
+
+        pack_root_quoted = shlex.quote(remote_pack_root)
+        staged_project_quoted = shlex.quote(staged_project_dir)
+        output_root_quoted = shlex.quote(output_root)
+        setup_project_quoted = shlex.quote(setup_project_dir)
+        project_envs_quoted = shlex.quote(project_envs_dir)
+        published_envs_quoted = shlex.quote(published_envs_dir)
+        activation_quoted = shlex.quote(activation_script)
+        python_quoted = shlex.quote(python_executable)
+        temporary_link_quoted = shlex.quote(temporary_link)
+
+        inner = f"""
+set -euo pipefail
+cleanup_failed_setup() {{
+  status=$?
+  rm -rf {pack_root_quoted} {output_root_quoted} {temporary_link_quoted}
+  exit "$status"
+}}
+trap cleanup_failed_setup ERR
+if [ {int(force_refresh)} -eq 0 ] && [ -f {activation_quoted} ] && [ -x {python_quoted} ]; then
+  rm -rf {pack_root_quoted}
+  trap - ERR
+  exit 0
+fi
+rm -rf {output_root_quoted}
+mkdir -p {setup_project_quoted}
+cp -a {staged_project_quoted}/. {setup_project_quoted}/
+cd {setup_project_quoted}
+{command}
+if [ ! -d {project_envs_quoted} ]; then
+  echo "Project setup completed but produced no named environments under .pixi/envs in the staged project." >&2
+  exit 1
+fi
+shopt -s nullglob
+python_bins=({project_envs_quoted}/*/bin/python)
+if [ "${{#python_bins[@]}}" -eq 0 ]; then
+  echo "Project setup produced no executable .pixi/envs/<name>/bin/python paths" >&2
+  exit 1
+fi
+for python_bin in "${{python_bins[@]}}"; do
+  if [ ! -x "$python_bin" ]; then
+    continue
+  fi
+  environment_dir="$(dirname "$(dirname "$python_bin")")"
+  if [ ! -f "$environment_dir/activate.sh" ]; then
+    environment="$(basename "$environment_dir")"
+    pixi shell-hook --shell bash -e "$environment" > "$environment_dir/activate.sh.tmp"
+    mv "$environment_dir/activate.sh.tmp" "$environment_dir/activate.sh"
+  fi
+done
+if [ ! -f {project_envs_quoted}/{shlex.quote(environment_name)}/activate.sh ] || [ ! -x {project_envs_quoted}/{shlex.quote(environment_name)}/bin/python ]; then
+  echo "Project setup did not produce requested environment {shlex.quote(environment_name)}" >&2
+  exit 1
+fi
+ln -s {project_envs_quoted} {temporary_link_quoted}
+mv -Tf {temporary_link_quoted} {published_envs_quoted}
+rm -rf {pack_root_quoted}
+trap - ERR
+"""
+        setup_cmd_remote = (
+            f"mkdir -p {shlex.quote(env_base_dir)} && "
+            f"flock {shlex.quote(lock_file)} bash -c {shlex.quote(inner)}"
+        )
+        self.logger.info(
+            "Running project setup command on the Slurm edge node for environment %s",
+            environment_name,
+        )
+        try:
+            output = ssh_pool.run(
+                setup_cmd_remote,
+                timeout=self.remote_pack_timeout,
+            )
+            self.logger.debug(f"Remote project setup output:\n{output}")
+        except Exception as exc:
+            raise RuntimeError(
+                "Remote project setup failed before Slurm submission. Command: "
+                f"{shlex.join(setup_cmd)}. Requested environment: "
+                f"{environment_name}. Error: {exc}"
+            ) from exc
+
+        ssh_pool.run(f"test -f {activation_quoted} && test -x {python_quoted}")
+        self.logger.info(
+            "Project environment %s is ready at %s",
+            environment_name,
+            python_executable,
+        )
+        return activation_script, python_executable
 
     def _pack_environment_on_remote(
         self,
@@ -1807,6 +2024,7 @@ rm -rf {pack_root_quoted}
         force_env_push: bool,
         pack_cmd_override: Optional[list[str]] = None,
         pre_deployed_env_path_override: Optional[str] = None,
+        environment_name: Optional[str] = None,
     ) -> tuple[str, str]:
         """Ensure a usable Python environment exists and return activation + python paths."""
         pre_deployed_env_path = (
@@ -1828,6 +2046,63 @@ rm -rf {pack_root_quoted}
             pack_env_overrides["SLURM_PACK_PLATFORM"],
         )
         resolved_pack_platform = pack_env_overrides["SLURM_PACK_PLATFORM"]
+
+        if self.project_setup_cmd:
+            if pack_cmd_override:
+                raise ValueError(
+                    "slurm_pack_cmd cannot be combined with project_setup_cmd. "
+                    "Use environment_name to select one environment produced by "
+                    "the project setup command."
+                )
+            if not environment_name:
+                raise ValueError(
+                    "environment_name is required when project_setup_cmd is "
+                    "configured. Pass it to ComputeResource.run(), set it in "
+                    "SlurmRunConfig, or use slurm_environment_name metadata."
+                )
+            environment_name = self._validate_environment_name(environment_name)
+            setup_cache_env = {
+                **self.project_setup_env,
+                **pack_env_overrides,
+            }
+            cache_key = self._compute_project_setup_cache_key(
+                setup_cmd=self.project_setup_cmd,
+                env_overrides=setup_cache_env,
+            )
+            env_base_dir = f"{remote_base}/env-cache/{cache_key}"
+            activation_script = f"{env_base_dir}/envs/{environment_name}/activate.sh"
+            python_executable = f"{env_base_dir}/envs/{environment_name}/bin/python"
+
+            if not force_env_push and self._cached_env_ready(
+                ssh_pool=ssh_pool,
+                activation_script=activation_script,
+                python_executable=python_executable,
+            ):
+                self.logger.info(
+                    "Reusing project environment %s from cache %s",
+                    environment_name,
+                    cache_key,
+                )
+                return activation_script, python_executable
+
+            if force_env_push:
+                self.logger.info(
+                    "Force refreshing project environments in cache %s",
+                    cache_key,
+                )
+            else:
+                self.logger.info(
+                    "Project environment cache miss for %s; running setup",
+                    cache_key,
+                )
+            return self._setup_project_environments_on_remote(
+                ssh_pool=ssh_pool,
+                env_base_dir=env_base_dir,
+                setup_cmd=self.project_setup_cmd,
+                environment_name=environment_name,
+                env_overrides=pack_env_overrides,
+                force_refresh=force_env_push,
+            )
 
         # Use pack-only command for cache key computation (stable keys)
         pack_cmd_for_cache = self._get_pack_command(

--- a/projects/dagster-slurm/dagster_slurm/resources/compute.py
+++ b/projects/dagster-slurm/dagster_slurm/resources/compute.py
@@ -163,6 +163,36 @@ class ComputeResource(ConfigurableResource):
         description="Timeout in seconds for remote environment packing on the edge node.",
     )
 
+    project_setup_cmd: Optional[List[str]] = Field(
+        default=None,
+        description=(
+            "Optional project-level command that prepares multiple named environments "
+            "on the Slurm edge node. The command runs from a durable staged project "
+            "directory inside the existing environment cache."
+        ),
+    )
+
+    project_setup_env: Dict[str, str] = Field(
+        default_factory=dict,
+        description="Environment variables passed to project_setup_cmd.",
+    )
+
+    project_setup_input_globs: Optional[List[str]] = Field(
+        default=None,
+        description=(
+            "Additional project-relative glob patterns staged for project_setup_cmd. "
+            "Pixi manifests, pixi.lock, and Justfiles are staged automatically."
+        ),
+    )
+
+    default_environment_name: Optional[str] = Field(
+        default=None,
+        description=(
+            "Default named environment produced by project_setup_cmd. Can be "
+            "overridden per run or with slurm_environment_name asset metadata."
+        ),
+    )
+
     cache_inject_globs: Optional[List[str]] = Field(
         default=None,
         description=(
@@ -336,6 +366,9 @@ class ComputeResource(ConfigurableResource):
                 cache_inject_globs=self.cache_inject_globs,
                 pack_on_remote=self.pack_on_remote,
                 remote_pack_timeout=self.remote_pack_timeout,
+                project_setup_cmd=self.project_setup_cmd,
+                project_setup_env=self.project_setup_env,
+                project_setup_input_globs=self.project_setup_input_globs,
             )
 
         elif self.mode == ExecutionMode.SLURM_SESSION:
@@ -360,6 +393,9 @@ class ComputeResource(ConfigurableResource):
                 cache_inject_globs=self.cache_inject_globs,
                 pack_on_remote=self.pack_on_remote,
                 remote_pack_timeout=self.remote_pack_timeout,
+                project_setup_cmd=self.project_setup_cmd,
+                project_setup_env=self.project_setup_env,
+                project_setup_input_globs=self.project_setup_input_globs,
             )
 
         else:  # ExecutionMode.SLURM_HETJOB
@@ -378,6 +414,9 @@ class ComputeResource(ConfigurableResource):
                 cache_inject_globs=self.cache_inject_globs,
                 pack_on_remote=self.pack_on_remote,
                 remote_pack_timeout=self.remote_pack_timeout,
+                project_setup_cmd=self.project_setup_cmd,
+                project_setup_env=self.project_setup_env,
+                project_setup_input_globs=self.project_setup_input_globs,
             )
 
     def _get_or_create_run_allocation_session(
@@ -771,6 +810,33 @@ class ComputeResource(ConfigurableResource):
 
         return pack_cmd_override, pre_deployed_env_path
 
+    def _resolve_environment_name(self, context) -> Optional[str]:
+        """Read one named project environment from selected asset metadata."""
+        metadata_by_key = self._get_metadata_by_key(context)
+        if not metadata_by_key:
+            return None
+
+        environment_names: list[str] = []
+        for key in self._extract_asset_keys(context):
+            metadata = metadata_by_key.get(key, {})
+            if not isinstance(metadata, dict):
+                continue
+            value = metadata.get("slurm_environment_name")
+            if value is None:
+                continue
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(
+                    "slurm_environment_name asset metadata must be a non-empty string"
+                )
+            environment_names.append(value.strip())
+
+        unique_names = list(dict.fromkeys(environment_names))
+        if len(unique_names) > 1:
+            raise ValueError(
+                "Conflicting slurm_environment_name values found across asset outputs."
+            )
+        return unique_names[0] if unique_names else None
+
     def run(
         self,
         context,
@@ -781,6 +847,7 @@ class ComputeResource(ConfigurableResource):
         force_env_push: Optional[bool] = None,
         skip_payload_upload: Optional[bool] = None,
         remote_payload_path: Optional[str] = None,
+        environment_name: Optional[str] = None,
         config: Optional[SlurmRunConfig] = None,
         extra_files: Optional[List[str]] = None,
         poll_timeout: int = 3600,
@@ -810,6 +877,9 @@ class ComputeResource(ConfigurableResource):
                 or asset metadata key 'skip_slurm_payload_upload'.
             remote_payload_path: Remote path to an existing payload when skipping upload.
                 Falls back to config.remote_payload_path or asset metadata.
+            environment_name: Named environment produced by project_setup_cmd.
+                Falls back to config.environment_name, slurm_environment_name asset
+                metadata, then default_environment_name.
             config: Optional SlurmRunConfig for run-time configuration via launchpad.
                 Values from config are used as defaults, but explicit parameters take precedence.
             extra_files: List of local file paths to upload alongside the payload.
@@ -875,6 +945,7 @@ class ComputeResource(ConfigurableResource):
         effective_force_env_push = force_env_push
         effective_skip_payload_upload = skip_payload_upload
         effective_remote_payload_path = remote_payload_path
+        effective_environment_name = environment_name
 
         if config is not None:
             if effective_force_env_push is None:
@@ -883,6 +954,13 @@ class ComputeResource(ConfigurableResource):
                 effective_skip_payload_upload = config.skip_payload_upload
             if effective_remote_payload_path is None:
                 effective_remote_payload_path = config.remote_payload_path
+            if effective_environment_name is None:
+                effective_environment_name = config.environment_name
+
+        if effective_environment_name is None and self.project_setup_cmd:
+            effective_environment_name = (
+                self._resolve_environment_name(context) or self.default_environment_name
+            )
 
         # Determine effective launcher
         effective_launcher = self._resolve_launcher(launcher)
@@ -958,6 +1036,8 @@ class ComputeResource(ConfigurableResource):
                 kwargs["pack_cmd_override"] = pack_cmd_override
             if pre_deployed_env_override:
                 kwargs["pre_deployed_env_path_override"] = pre_deployed_env_override
+            if effective_environment_name:
+                kwargs["environment_name"] = effective_environment_name
         elif resolved_force_env_push:
             logger.debug(
                 "force_env_push requested but ignored because execution is not using Slurm"

--- a/projects/dagster-slurm/dagster_slurm_test/test_env_caching.py
+++ b/projects/dagster-slurm/dagster_slurm_test/test_env_caching.py
@@ -3,6 +3,8 @@
 import os
 import shutil
 import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
@@ -755,6 +757,207 @@ exec "$@"
     assert not any(Path(src).name == "environment.sh" for src, _ in pool.uploads)
 
 
+def _write_project_setup_fixture(project_dir: Path, *, fail: bool = False) -> None:
+    """Create a two-environment Pixi-style project setup fixture."""
+    (project_dir / "pyproject.toml").write_text(
+        "[tool.pixi.workspace]\nchannels = []\nplatforms = ['linux-64']\n",
+        encoding="utf-8",
+    )
+    (project_dir / "pixi.lock").write_text("lock", encoding="utf-8")
+    (project_dir / "justfile").write_text("setup-gpu:\n    bash setup.sh\n")
+    failure = 'echo "intentional setup failure" >&2\nexit 7\n' if fail else ""
+    (project_dir / "setup.sh").write_text(
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+test "$PWD" = "$DAGSTER_SLURM_REMOTE_PROJECT_DIR"
+test "$CUSTOM_SETUP_VALUE" = "configured"
+{failure}mkdir -p .pixi/envs/cpu/bin .pixi/envs/gpu/bin
+for environment in cpu gpu; do
+  printf '#!/usr/bin/env bash\\n' > ".pixi/envs/$environment/bin/python"
+  chmod +x ".pixi/envs/$environment/bin/python"
+  printf 'export PROJECT_SETUP_ENV=%q\\n' "$environment" > ".pixi/envs/$environment/activate.sh"
+done
+printf 'setup-ran\\n' >> "$DAGSTER_SLURM_ENV_BASE_DIR/setup-count"
+""",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="The local remote-shell fixture exercises Linux flock and mv semantics",
+)
+def test_project_setup_publishes_multiple_named_environments(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    slurm_client_factory: Callable[..., SlurmPipesClient],
+):
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    _write_project_setup_fixture(project_dir)
+    monkeypatch.chdir(project_dir)
+    monkeypatch.setattr(
+        "dagster_slurm.pipes_clients.slurm_pipes_client.pack_environment_with_pixi",
+        lambda **_: (_ for _ in ()).throw(
+            AssertionError("project setup must not fall back to local pixi-pack")
+        ),
+    )
+
+    client = slurm_client_factory(
+        project_setup_cmd=["bash", "setup.sh"],
+        project_setup_env={"CUSTOM_SETUP_VALUE": "configured"},
+        project_setup_input_globs=["setup.sh"],
+        remote_pack_timeout=10,
+    )
+    pool = LocalShellPool()
+    remote_base = tmp_path / "remote"
+
+    activation, python_executable = client._prepare_environment(
+        ssh_pool=cast(Any, pool),
+        remote_base=str(remote_base),
+        run_dir=str(remote_base / "runs" / "run1"),
+        force_env_push=False,
+        environment_name="gpu",
+    )
+
+    assert Path(activation).is_file()
+    assert Path(python_executable).is_file()
+    envs_dir = Path(python_executable).parents[2]
+    assert (envs_dir / "cpu" / "bin" / "python").is_file()
+    assert (envs_dir / "gpu" / "bin" / "python").is_file()
+    assert (envs_dir / "cpu" / "activate.sh").is_file()
+    assert (envs_dir / "gpu" / "activate.sh").is_file()
+    env_base_dir = envs_dir.parent
+    assert (env_base_dir / "setup-count").read_text() == "setup-ran\n"
+    assert not (env_base_dir / "pack-work").exists() or not any(
+        (env_base_dir / "pack-work").iterdir()
+    )
+
+    cached_activation, cached_python = client._prepare_environment(
+        ssh_pool=cast(Any, pool),
+        remote_base=str(remote_base),
+        run_dir=str(remote_base / "runs" / "run2"),
+        force_env_push=False,
+        environment_name="cpu",
+    )
+
+    assert Path(cached_activation).is_file()
+    assert Path(cached_python).is_file()
+    assert (env_base_dir / "setup-count").read_text() == "setup-ran\n"
+
+    refreshed_activation, refreshed_python = client._prepare_environment(
+        ssh_pool=cast(Any, pool),
+        remote_base=str(remote_base),
+        run_dir=str(remote_base / "runs" / "run3"),
+        force_env_push=True,
+        environment_name="gpu",
+    )
+
+    assert Path(refreshed_activation).is_file()
+    assert Path(refreshed_python).is_file()
+    assert (env_base_dir / "setup-count").read_text() == "setup-ran\nsetup-ran\n"
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="The local remote-shell fixture exercises Linux flock and mv semantics",
+)
+def test_project_setup_failure_blocks_environment_preparation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    slurm_client_factory: Callable[..., SlurmPipesClient],
+):
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    _write_project_setup_fixture(project_dir, fail=True)
+    monkeypatch.chdir(project_dir)
+    monkeypatch.setattr(
+        "dagster_slurm.pipes_clients.slurm_pipes_client.pack_environment_with_pixi",
+        lambda **_: (_ for _ in ()).throw(
+            AssertionError("failed project setup must not fall back")
+        ),
+    )
+
+    client = slurm_client_factory(
+        project_setup_cmd=["bash", "setup.sh"],
+        project_setup_env={"CUSTOM_SETUP_VALUE": "configured"},
+        project_setup_input_globs=["setup.sh"],
+        remote_pack_timeout=10,
+    )
+    remote_base = tmp_path / "remote"
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"Remote project setup failed.*bash setup\.sh.*gpu",
+    ):
+        client._prepare_environment(
+            ssh_pool=cast(Any, LocalShellPool()),
+            remote_base=str(remote_base),
+            run_dir=str(remote_base / "runs" / "run1"),
+            force_env_push=False,
+            environment_name="gpu",
+        )
+
+    assert not list(remote_base.glob("env-cache/*/envs"))
+
+
+def test_project_setup_rejects_unsafe_names(
+    slurm_client_factory: Callable[..., SlurmPipesClient],
+):
+    client = slurm_client_factory()
+
+    with pytest.raises(ValueError, match="environment_name"):
+        client._validate_environment_name("../gpu")
+    with pytest.raises(ValueError, match="invalid environment variable"):
+        client._validate_environment_variables({"SAFE": "yes", "NOT-SAFE": "no"})
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="The local remote-shell fixture exercises Linux flock and mv semantics",
+)
+def test_concurrent_project_setup_runs_command_once(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    slurm_client_factory: Callable[..., SlurmPipesClient],
+):
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    _write_project_setup_fixture(project_dir)
+    monkeypatch.chdir(project_dir)
+
+    client = slurm_client_factory(
+        project_setup_cmd=["bash", "setup.sh"],
+        project_setup_env={"CUSTOM_SETUP_VALUE": "configured"},
+        project_setup_input_globs=["setup.sh"],
+        remote_pack_timeout=10,
+    )
+    remote_base = tmp_path / "remote"
+    cache_key = client._compute_project_setup_cache_key(
+        setup_cmd=["bash", "setup.sh"],
+        env_overrides={
+            "CUSTOM_SETUP_VALUE": "configured",
+            "SLURM_PACK_PLATFORM": "linux-64",
+        },
+    )
+    env_base_dir = remote_base / "env-cache" / cache_key
+
+    def prepare() -> tuple[str, str]:
+        return client._setup_project_environments_on_remote(
+            ssh_pool=cast(Any, LocalShellPool()),
+            env_base_dir=str(env_base_dir),
+            setup_cmd=["bash", "setup.sh"],
+            environment_name="gpu",
+            env_overrides={"SLURM_PACK_PLATFORM": "linux-64"},
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(lambda _: prepare(), range(2)))
+
+    assert results[0] == results[1]
+    assert (env_base_dir / "setup-count").read_text() == "setup-ran\n"
+
+
 def test_remote_pack_flow_supports_inputs_above_project_dir(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -1250,6 +1453,65 @@ def test_predeployed_env_override_from_metadata(monkeypatch):
     assert fake_client.kwargs["pre_deployed_env_path_override"] == "/prebuilt/envs/ml"
 
 
+def test_named_environment_resolution_precedence(monkeypatch):
+    slurm_resource = SlurmResource(
+        ssh=SSHConnectionResource(
+            host="localhost", port=2222, user="test", password="secret"
+        ),
+        queue=SlurmQueueConfig(),
+        remote_base="/tmp/dagster_test",
+    )
+    resource = ComputeResource(
+        mode=ExecutionMode.SLURM,
+        slurm=slurm_resource,
+        default_launcher=BashLauncher(),
+        project_setup_cmd=["just", "setup-gpu"],
+        default_environment_name="default",
+    )
+
+    class DummyContext:
+        def __init__(self):
+            self.asset_key = AssetKey("demo")
+            self.selected_asset_keys = {self.asset_key}
+            self.assets_def = SimpleNamespace(
+                metadata_by_key={self.asset_key: {"slurm_environment_name": "metadata"}}
+            )
+
+        def has_assets_def(self):
+            return True
+
+    fake_client = DummySlurmClient()
+    monkeypatch.setattr(
+        ComputeResource,
+        "get_pipes_client",
+        lambda self, context, launcher=None: fake_client,
+    )
+
+    resource.run(context=DummyContext(), payload_path="script.py")
+    captured = fake_client.kwargs
+    assert captured is not None
+    assert captured["environment_name"] == "metadata"
+
+    resource.run(
+        context=DummyContext(),
+        payload_path="script.py",
+        config=SlurmRunConfig(environment_name="config"),
+    )
+    captured = fake_client.kwargs
+    assert captured is not None
+    assert captured["environment_name"] == "config"
+
+    resource.run(
+        context=DummyContext(),
+        payload_path="script.py",
+        config=SlurmRunConfig(environment_name="config"),
+        environment_name="explicit",
+    )
+    captured = fake_client.kwargs
+    assert captured is not None
+    assert captured["environment_name"] == "explicit"
+
+
 def test_slurm_run_config_sets_force_env_push(monkeypatch):
     """SlurmRunConfig should set force_env_push when passed to compute.run()."""
     slurm_resource = SlurmResource(
@@ -1346,6 +1608,9 @@ def test_compute_resource_passes_remote_pack_options_to_slurm_client():
         default_launcher=BashLauncher(),
         pack_on_remote=True,
         remote_pack_timeout=321,
+        project_setup_cmd=["just", "setup-gpu"],
+        project_setup_env={"MODEL_CACHE": "/share/models"},
+        project_setup_input_globs=["scripts/setup-*.sh"],
     )
 
     client = resource.get_pipes_client(cast(Any, SimpleNamespace()))
@@ -1353,6 +1618,9 @@ def test_compute_resource_passes_remote_pack_options_to_slurm_client():
     assert isinstance(client, SlurmPipesClient)
     assert client.pack_on_remote is True
     assert client.remote_pack_timeout == 321
+    assert client.project_setup_cmd == ["just", "setup-gpu"]
+    assert client.project_setup_env == {"MODEL_CACHE": "/share/models"}
+    assert client.project_setup_input_globs == ["scripts/setup-*.sh"]
 
 
 def test_explicit_params_override_config(monkeypatch):

--- a/projects/dagster-slurm/dagster_slurm_test/test_remote_pack_integration.py
+++ b/projects/dagster-slurm/dagster_slurm_test/test_remote_pack_integration.py
@@ -1,6 +1,7 @@
 """Docker-backed integration coverage for remote environment packaging."""
 
 import os
+import shlex
 import uuid
 from pathlib import Path
 from typing import Any, cast
@@ -110,5 +111,148 @@ chmod +x environment.sh
                     ]
                 )
             )
+        finally:
+            pool.run(f"rm -rf {remote_root}")
+
+
+def test_project_setup_on_docker_edge_node(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Install, activate, execute, reuse, and refresh two real Pixi environments."""
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    (project_dir / "pixi.toml").write_text(
+        """[workspace]
+channels = ["conda-forge"]
+platforms = ["linux-64"]
+
+[dependencies]
+python = "3.12.*"
+
+[feature.cpu.activation.env]
+DAGSTER_SLURM_TEST_ENV = "cpu"
+
+[feature.cpu.activation]
+scripts = ["activate-cpu.sh"]
+
+[feature.gpu.activation.env]
+DAGSTER_SLURM_TEST_ENV = "gpu"
+
+[feature.gpu.activation]
+scripts = ["activate-gpu.sh"]
+
+[environments]
+cpu = ["cpu"]
+gpu = ["gpu"]
+""",
+        encoding="utf-8",
+    )
+    for environment in ("cpu", "gpu"):
+        (project_dir / f"activate-{environment}.sh").write_text(
+            f"export DAGSTER_SLURM_TEST_SCRIPT={environment}-script\n",
+            encoding="utf-8",
+        )
+    (project_dir / "setup.sh").write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+test "$SETUP_KIND" = "multi-environment"
+pixi install --all
+printf 'setup-ran\n' >> "$DAGSTER_SLURM_ENV_BASE_DIR/setup-count"
+""",
+        encoding="utf-8",
+    )
+
+    remote_root = f"/home/submitter/dagster_ci_runs/project-setup-{uuid.uuid4().hex}"
+    ssh = SSHConnectionResource(
+        host=os.environ.get("SLURM_EDGE_NODE_HOST", "127.0.0.1"),
+        port=int(os.environ.get("SLURM_EDGE_NODE_PORT", "2223")),
+        user=os.environ.get("SLURM_EDGE_NODE_USER", "submitter"),
+        password=os.environ.get("SLURM_EDGE_NODE_PASSWORD", "submitter"),
+    )
+    slurm = SlurmResource(ssh=ssh, queue=SlurmQueueConfig(), remote_base=remote_root)
+    client = SlurmPipesClient(
+        slurm_resource=slurm,
+        launcher=BashLauncher(),
+        project_setup_cmd=["bash", "setup.sh"],
+        project_setup_env={"SETUP_KIND": "multi-environment"},
+        project_setup_input_globs=["setup.sh", "activate-*.sh"],
+        remote_pack_timeout=60,
+    )
+
+    monkeypatch.chdir(project_dir)
+    pool = SSHConnectionPool(ssh)
+    with pool:
+        try:
+            activation_script, python_executable = client._prepare_environment(
+                ssh_pool=cast(Any, pool),
+                remote_base=remote_root,
+                run_dir=f"{remote_root}/runs/run-1",
+                force_env_push=False,
+                environment_name="gpu",
+            )
+
+            assert activation_script.endswith("/envs/gpu/activate.sh")
+            assert python_executable.endswith("/envs/gpu/bin/python")
+            envs_dir = python_executable.removesuffix("/gpu/bin/python")
+            env_base_dir = envs_dir.removesuffix("/envs")
+            pool.run(
+                " && ".join(
+                    [
+                        f"test -x {envs_dir}/cpu/bin/python",
+                        f"test -x {envs_dir}/gpu/bin/python",
+                        f"test -f {envs_dir}/cpu/activate.sh",
+                        f"test -f {envs_dir}/gpu/activate.sh",
+                        f"test $(wc -l < {env_base_dir}/setup-count) -eq 1",
+                    ]
+                )
+            )
+
+            def execute_in_environment(
+                activation: str,
+                expected_environment: str,
+            ) -> str:
+                python_code = (
+                    "import os, sys; "
+                    f"assert os.environ['DAGSTER_SLURM_TEST_ENV'] == "
+                    f"{expected_environment!r}; "
+                    f"assert os.environ['DAGSTER_SLURM_TEST_SCRIPT'] == "
+                    f"{f'{expected_environment}-script'!r}; "
+                    "print(sys.executable)"
+                )
+                activated_command = (
+                    f"source {shlex.quote(activation)} && "
+                    f"python -c {shlex.quote(python_code)}"
+                )
+                return pool.run(f"bash -c {shlex.quote(activated_command)}").strip()
+
+            assert execute_in_environment(activation_script, "gpu").endswith(
+                "/.pixi/envs/gpu/bin/python"
+            )
+
+            cached_activation, cached_python = client._prepare_environment(
+                ssh_pool=cast(Any, pool),
+                remote_base=remote_root,
+                run_dir=f"{remote_root}/runs/run-2",
+                force_env_push=False,
+                environment_name="cpu",
+            )
+            assert cached_python.endswith("/envs/cpu/bin/python")
+            assert execute_in_environment(cached_activation, "cpu").endswith(
+                "/.pixi/envs/cpu/bin/python"
+            )
+            pool.run(f"test $(wc -l < {env_base_dir}/setup-count) -eq 1")
+
+            refreshed_activation, _ = client._prepare_environment(
+                ssh_pool=cast(Any, pool),
+                remote_base=remote_root,
+                run_dir=f"{remote_root}/runs/run-3",
+                force_env_push=True,
+                environment_name="gpu",
+            )
+            assert execute_in_environment(refreshed_activation, "gpu").endswith(
+                "/.pixi/envs/gpu/bin/python"
+            )
+            pool.run(f"test $(wc -l < {env_base_dir}/setup-count) -eq 2")
         finally:
             pool.run(f"rm -rf {remote_root}")


### PR DESCRIPTION
## Summary

- add project-level edge-node setup hooks that prepare and atomically publish multiple named Pixi environments in one cache lifecycle
- select named environments through `compute.run`, `SlurmRunConfig`, asset metadata, or a resource default
- make `force_env_push=True` rerun setup inside the lock and replace the published environment set atomically
- preserve supplied activation scripts or generate complete Pixi hooks with `pixi shell-hook`, including activation variables and scripts
- document shared-storage behavior and optional node-local scratch staging

## Validation

- `pixi run -e build --frozen fmt`
- `pixi run -e build --frozen lint`
- `pixi run -e build --frozen test` (172 passed)
- focused project setup tests (5 passed)
- Docker SSH integration with two real Pixi environments, activation, interpreter execution, cache reuse, and forced refresh (1 passed)

Closes #173