### PR TITLE
fix: make stable release notes cumulative

### DIFF
--- a/.github/workflows/library.yaml
+++ b/.github/workflows/library.yaml
@@ -564,6 +564,44 @@ jobs:
           git push --tags
           pixi run -e build --frozen uv run semantic-release publish
 
+      - name: Generate cumulative stable release notes
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+        run: |
+          set -euo pipefail
+          RELEASE_VERSION="$(grep "version =" pyproject.toml | head -1 | cut -d'"' -f2)"
+          FINAL_TAG="v$RELEASE_VERSION"
+
+          if ! gh release view "$FINAL_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null; then
+            echo "Published stable release $FINAL_TAG was not found" >&2
+            exit 1
+          fi
+
+          PREVIOUS_STABLE_TAG="$(
+            gh release list \
+              --repo "$GITHUB_REPOSITORY" \
+              --exclude-drafts \
+              --exclude-pre-releases \
+              --limit 2 \
+              --json tagName \
+              --jq '.[1].tagName // empty'
+          )"
+          if [ -z "$PREVIOUS_STABLE_TAG" ]; then
+            echo "No previous stable release was found before $FINAL_TAG" >&2
+            exit 1
+          fi
+
+          echo "Generating release notes for $PREVIOUS_STABLE_TAG...$FINAL_TAG"
+          gh api \
+            --method POST \
+            "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
+            -f tag_name="$FINAL_TAG" \
+            -f previous_tag_name="$PREVIOUS_STABLE_TAG" \
+            --jq .body |
+            gh release edit "$FINAL_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --notes-file -
+
       - name: Upload distribution artifacts
         uses: actions/upload-artifact@v7.0.1
         with:


### PR DESCRIPTION
## Summary

- generate final release notes with GitHub’s native `releases/generate-notes` endpoint
- compare the previous stable tag directly with the newly published stable tag, so all changes exercised through RCs appear once
- replace the final release body idempotently after `semantic-release publish`
- fail loudly when the final release or previous stable release cannot be found, or when generation/update fails
- remove the custom prerelease-body parser, CLI wrapper, and duplicate changelog model

## Validation

- `pixi run -e build --frozen fmt`
- `pixi run -e build --frozen lint`
- historical native generation for `v1.15.1...v1.15.2` includes PR #172 and excludes generated lockfile-only notes
- historical native generation for `v1.14.0...v1.15.1` includes the complete merged-PR window and one stable comparison link
- repeated native generation returned byte-identical output
- missing-previous-stable selection returns empty and reaches the explicit failure path

Closes #176