### PR TITLE
fix: retry tutorial environment packing

### DIFF
--- a/.github/workflows/tutorial.yaml
+++ b/.github/workflows/tutorial.yaml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - ".github/actions/setup-devenv/**"
+      - ".github/workflows/tutorial.yaml"
       - "devenv.*"
       - "examples/**"
       - "nix/**"
@@ -15,6 +16,7 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - ".github/actions/setup-devenv/**"
+      - ".github/workflows/tutorial.yaml"
       - "devenv.*"
       - "examples/**"
       - "nix/**"
@@ -58,7 +60,26 @@ jobs:
 
       - run: bash -lc 'cd examples && pixi run -e dev --frozen test'
 
-      - run: bash -lc 'cd examples && pixi run pack'
+      - name: Pack tutorial environment
+        run: |
+          max_attempts=3
+
+          for attempt in $(seq 1 "${max_attempts}"); do
+            if bash -lc 'cd examples && pixi run pack'; then
+              exit 0
+            fi
+
+            rm -f examples/environment.sh examples/environment.tar
+
+            if [[ "${attempt}" -eq "${max_attempts}" ]]; then
+              echo "::error::Packing tutorial environment failed after ${max_attempts} attempts."
+              exit 1
+            fi
+
+            delay_seconds=$((attempt * 15))
+            echo "::warning::Packing tutorial environment failed on attempt ${attempt}/${max_attempts}; retrying in ${delay_seconds}s."
+            sleep "${delay_seconds}"
+          done
 
       - name: Store Packed Environment as Artifact
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary

- Retry tutorial environment packing up to three times with 15-second incremental backoff.
- Remove partial pack archives between attempts and preserve a hard failure after the final attempt.
- Trigger tutorial validation when its workflow file changes so future workflow-only PRs exercise the workflow.

## Cause

The failed job encountered an `error sending request` while `pixi-pack` downloaded a locked wheel from `files.pythonhosted.org`. The log did not contain an HTTP 429, so this is treated as a transient network/CDN failure rather than confirmed throttling.

Failed job: https://github.com/ascii-supply-networks/dagster-slurm/actions/runs/30522537403/job/90805953704

## Validation

- `pixi run -e build --frozen fmt`
- `pixi run -e build --frozen lint`
- `bash -n` on the workflow retry script
- Manual tutorial workflow run passed, including environment packing: https://github.com/ascii-supply-networks/dagster-slurm/actions/runs/30523558543