### PR TITLE
feat: reuse and self-heal the ssh controlmaster

### DIFF
--- a/docs/docs/how-to/troubleshooting.md
+++ b/docs/docs/how-to/troubleshooting.md
@@ -5,21 +5,52 @@ title: Troubleshooting connectivity & logs
 
 The `dagster-slurm` presets hide most SSH and Slurm plumbing, but a few deployment-specific quirks are worth calling out. The tips below keep log streaming responsive, explain how to retain run artefacts for inspection, and silence noisy shells in the Docker sandbox.
 
-## Log streaming without ControlMaster
+## SSH connection multiplexing
 
-Some HPC centres (e.g. VSC-5) disable SSH ControlMaster sockets. When that happens the Dagster code location automatically falls back to password-aware connections and polls the remote log files. You still get live output, but a few tweaks make the experience smoother:
+Supervising a Slurm job is chatty: status polling, log tailing and Pipes message reading all talk to the login node. Without multiplexing every one of those would be a separate DNS lookup, TCP handshake and authentication. HPC centres rate-limit — and increasingly block — accounts that do this, so `dagster-slurm` funnels **every** SSH and SCP invocation through a single shared OpenSSH ControlMaster connection per `user@host:port`.
 
-- Set `DAGSTER_SLURM_SSH_CONTROL_DIR` if your site restricts socket paths. The default is `~/.ssh/dagster-slurm`; point it to a writable directory on shared machines.
-- Leave `SLURM_EDGE_NODE_FORCE_TTY=false` unless your cluster explicitly requires a TTY. Password-based sessions request one automatically.
-- If you rely on jump hosts or OTP prompts, prefer a local `~/.ssh/config` entry. The same configuration is reused by the Pipes log tailer.
+The socket lives at `~/.ssh/dagster-slurm/cm-<user>@<host>:<port>` and is deliberately **not** per-process: a master started by one Dagster step, sensor tick or CLI helper is reused by the next one. It is left running after a run finishes and expires on its own via `ControlPersist`.
 
-When the connection falls back to polling, Dagster prints a debug line such as:
+| Variable                                 | Default                | Purpose                                                                                                 |
+| ---------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------- |
+| `DAGSTER_SLURM_SSH_CONTROL_DIR`          | `~/.ssh/dagster-slurm` | Where control sockets are stored. Point it at a writable directory if your site restricts socket paths. |
+| `DAGSTER_SLURM_SSH_CONTROL_PERSIST`      | `10m`                  | How long an idle master stays alive after the last command.                                             |
+| `DAGSTER_SLURM_SSH_CLOSE_MASTER_ON_EXIT` | unset                  | Set to `1` to tear the master down when a run ends instead of leaving it for reuse.                     |
+
+Note that these command-line options take precedence over `~/.ssh/config`, so a `ControlPath` entry there will not change what `dagster-slurm` does — it only affects SSH commands you run yourself.
+
+### When multiplexing is unavailable
+
+Password-based authentication (on the target or on a jump host) cannot be multiplexed, because a shared connection has nowhere to answer a prompt. In that case Dagster falls back to one-off connections and polls the remote log files instead of tailing them, printing a debug line such as:
 
 ```
 Streaming ... via polling fallback (ControlMaster unavailable)
 ```
 
-This is expected and no changes are required unless you notice missing output.
+Use key-based authentication wherever possible. If the master fails to start, or dies mid-run and cannot be restarted, Dagster logs a run-level error:
+
+```
+SSH MULTIPLEXING FAILED for <host>. Dagster is falling back to one-off SSH connections. ...
+```
+
+Treat that as actionable: stop the run and fix the SSH configuration before the connection rate becomes a problem for the site.
+
+Other tips:
+
+- Leave `SLURM_EDGE_NODE_FORCE_TTY=false` unless your cluster explicitly requires a TTY. Password-based sessions request one automatically.
+- If you rely on jump hosts or OTP prompts, prefer a local `~/.ssh/config` entry. The same configuration is reused by the Pipes log tailer.
+
+## Slurm status polling cadence
+
+While a job runs, its state is polled over the shared connection. The interval starts at `status_poll_interval_seconds` and backs off by `status_poll_backoff_factor` up to `status_poll_max_interval_seconds` for as long as the state stays unchanged; any state transition resets it, so completion is still noticed promptly.
+
+| Variable                         | Field                              | Default |
+| -------------------------------- | ---------------------------------- | ------- |
+| `SLURM_STATUS_POLL_INTERVAL`     | `status_poll_interval_seconds`     | `2.0`   |
+| `SLURM_STATUS_POLL_MAX_INTERVAL` | `status_poll_max_interval_seconds` | `15.0`  |
+| `SLURM_STATUS_POLL_BACKOFF`      | `status_poll_backoff_factor`       | `1.5`   |
+
+Raise these if your site asks for fewer `squeue`/`sacct` queries; lower them if you need tighter completion latency and the site is happy with the load.
 
 ## How SSH settings interact with `~/.ssh/config`
 

--- a/docs/docs/how-to/troubleshooting.md
+++ b/docs/docs/how-to/troubleshooting.md
@@ -47,10 +47,12 @@ While a job runs, its state is polled over the shared connection. The interval s
 | Variable                         | Field                              | Default |
 | -------------------------------- | ---------------------------------- | ------- |
 | `SLURM_STATUS_POLL_INTERVAL`     | `status_poll_interval_seconds`     | `2.0`   |
-| `SLURM_STATUS_POLL_MAX_INTERVAL` | `status_poll_max_interval_seconds` | `15.0`  |
+| `SLURM_STATUS_POLL_MAX_INTERVAL` | `status_poll_max_interval_seconds` | `5.0`   |
 | `SLURM_STATUS_POLL_BACKOFF`      | `status_poll_backoff_factor`       | `1.5`   |
 
-Raise these if your site asks for fewer `squeue`/`sacct` queries; lower them if you need tighter completion latency and the site is happy with the load.
+Raise these if your site asks for fewer `squeue`/`sacct` queries; lower them if you need tighter completion latency and the site is happy with the load. At the defaults a four-hour job costs about 2,880 status queries instead of 14,400, and completion is never noticed more than `status_poll_max_interval_seconds` late.
+
+The sleep is clamped to the remaining `poll_timeout` budget, so backing off can never step over the deadline and report a job that finished in time as a timeout.
 
 ## How SSH settings interact with `~/.ssh/config`
 

--- a/projects/dagster-slurm/dagster_slurm/helpers/message_readers.py
+++ b/projects/dagster-slurm/dagster_slurm/helpers/message_readers.py
@@ -16,6 +16,10 @@ from dagster_pipes import PipesDefaultMessageWriter
 if TYPE_CHECKING:  # pragma: no cover
     from .ssh_pool import SSHConnectionPool
 
+#: Upper bound for the degraded polling fallback, which pays a full SSH
+#: connection per round. Keeps log latency bounded without hammering SSH.
+MAX_FALLBACK_POLL_SECONDS = 15.0
+
 
 class _ClosedMessageTracker:
     """Track 'closed' messages to allow draining trailing stdio."""
@@ -193,20 +197,28 @@ class SSHMessageReader(PipesMessageReader):
         reconnect_interval: float = 2.0,
         max_reconnect_attempts: int = 10,
         ssh_pool: Optional["SSHConnectionPool"] = None,
+        max_reconnect_interval: float = 60.0,
+        healthy_session_seconds: float = 30.0,
     ):
         """Args:
         remote_path: Path to messages.jsonl on remote host
         ssh_config: SSHConnectionResource instance
         control_path: Path to ControlMaster socket (required for password auth)
-        reconnect_interval: Seconds to wait before reconnecting
-        max_reconnect_attempts: Maximum reconnection attempts.
+        reconnect_interval: Seconds to wait before the first reconnect
+        max_reconnect_attempts: Maximum consecutive failed reconnection attempts.
+        max_reconnect_interval: Upper bound for the exponential reconnect backoff.
+        healthy_session_seconds: Minimum lifetime for a tail session to count as
+            healthy. Shorter sessions keep incrementing the failure counter so a
+            flapping connection backs off instead of reconnecting forever.
 
         """
         self.remote_path = remote_path
         self.ssh_config = ssh_config
-        self.control_path = control_path
+        self._control_path = control_path
         self.reconnect_interval = reconnect_interval
         self.max_reconnect_attempts = max_reconnect_attempts
+        self.max_reconnect_interval = max_reconnect_interval
+        self.healthy_session_seconds = healthy_session_seconds
         self.logger = get_dagster_logger()
         self._proc: Optional[subprocess.Popen[str]] = None
         self._pexpect_child: Optional[Any] = None
@@ -219,6 +231,19 @@ class SSHMessageReader(PipesMessageReader):
         self._forwarded_lines: Dict[str, int] = {"stdout": 0, "stderr": 0}
         self._closed_message: Optional[Dict[str, Any]] = None
         self._closed_exception: Optional[Dict[str, Any]] = None
+
+    @property
+    def control_path(self) -> Optional[str]:
+        """Current ControlMaster socket, tracking the pool when one is attached.
+
+        The pool drops its socket when the master dies, and a reader still
+        pointing at the stale path would reconnect over a private connection
+        on every retry.
+        """
+        pool = self._ssh_pool
+        if pool is not None:
+            return getattr(pool, "control_path", self._control_path)
+        return self._control_path
 
     @contextmanager
     def read_messages(self, handler) -> Iterator[dict]:
@@ -305,6 +330,13 @@ class SSHMessageReader(PipesMessageReader):
             if isinstance(exception, dict):
                 self._closed_exception = exception
 
+    def _reconnect_delay(self, reconnect_count: int) -> float:
+        """Exponentially back off reconnects so a flapping tail cannot storm SSH."""
+        if reconnect_count <= 0:
+            return self.reconnect_interval
+        delay = self.reconnect_interval * (2 ** min(reconnect_count - 1, 6))
+        return min(delay, self.max_reconnect_interval)
+
     def _read_loop_with_reconnect(self, handler):
         """Read loop that automatically reconnects on failure.
 
@@ -318,6 +350,7 @@ class SSHMessageReader(PipesMessageReader):
         tracker = getattr(self, "_closed_tracker", _ClosedMessageTracker())
 
         while not self._stop_flag.is_set():
+            attempt_started = time.monotonic()
             try:
                 # Start tail process
                 ssh_cmd_optional = self._build_ssh_tail_command()
@@ -348,7 +381,6 @@ class SSHMessageReader(PipesMessageReader):
                 if self._requires_password_auth() and not self.control_path:
                     child = self._spawn_tail_with_password(ssh_cmd)
                     self._pexpect_child = child
-                    reconnect_count = 0
                     message_count = 0
 
                     for line in self._iter_pexpect_lines(child):
@@ -415,8 +447,6 @@ class SSHMessageReader(PipesMessageReader):
                         bufsize=1,
                     )
 
-                # Reset reconnect counter on successful start
-                reconnect_count = 0
                 message_count = 0
 
                 if self._proc and self._proc.stdout:
@@ -481,14 +511,28 @@ class SSHMessageReader(PipesMessageReader):
                     # )
                     break
 
-                # Unexpected exit - try to reconnect
-                if message_count > 0:
-                    # We received messages, so connection was working
+                # Unexpected exit - try to reconnect.  Progress alone is not
+                # enough to clear the failure counter: a tail that dies right
+                # after emitting a line would otherwise reconnect forever, and
+                # each reconnect is a full SSH handshake when the master is gone.
+                session_seconds = time.monotonic() - attempt_started
+                if (
+                    message_count > 0
+                    and session_seconds >= self.healthy_session_seconds
+                ):
                     self.logger.info(
-                        f"Tail process exited (code {return_code}). "
-                        f"Read {message_count} messages. Reconnecting..."
+                        f"Tail process exited (code {return_code}) after "
+                        f"{session_seconds:.0f}s. Read {message_count} messages. "
+                        "Reconnecting..."
                     )
-                    reconnect_count = 0  # Reset since we made progress
+                    reconnect_count = 0
+                elif message_count > 0:
+                    self.logger.warning(
+                        f"Tail process exited (code {return_code}) after only "
+                        f"{session_seconds:.0f}s. Read {message_count} messages. "
+                        "Treating the connection as unstable."
+                    )
+                    reconnect_count += 1
                 else:
                     # No messages received
                     self.logger.warning(
@@ -506,8 +550,9 @@ class SSHMessageReader(PipesMessageReader):
 
                 # Wait before reconnecting
                 if not self._stop_flag.is_set():
-                    self.logger.debug(f"Reconnecting in {self.reconnect_interval}s...")
-                    self._stop_flag.wait(self.reconnect_interval)
+                    delay = self._reconnect_delay(reconnect_count)
+                    self.logger.debug(f"Reconnecting in {delay}s...")
+                    self._stop_flag.wait(delay)
 
                 if tracker.maybe_flush(handler):
                     self._stop_flag.set()
@@ -528,7 +573,7 @@ class SSHMessageReader(PipesMessageReader):
                     break
 
                 if not self._stop_flag.is_set():
-                    self._stop_flag.wait(self.reconnect_interval)
+                    self._stop_flag.wait(self._reconnect_delay(reconnect_count))
 
                 if tracker.maybe_flush(handler):
                     self._stop_flag.set()
@@ -557,6 +602,9 @@ class SSHMessageReader(PipesMessageReader):
         quoted_path = shlex.quote(self.remote_path)
         next_line = self._fallback_next_line
         message_count = 0
+        # Each poll is a full SSH connection while the master is unavailable,
+        # so idle polling backs off instead of hammering the login node.
+        idle_rounds = 0
 
         self.logger.debug(
             "Polling %s for Pipes messages via SSH pool fallback",
@@ -618,8 +666,15 @@ class SSHMessageReader(PipesMessageReader):
                                 f"Error handling message: {e}", exc_info=True
                             )
                     next_line += processed_lines
+                    idle_rounds = 0
+                else:
+                    idle_rounds += 1
+            else:
+                idle_rounds += 1
 
-            self._stop_flag.wait(self.reconnect_interval)
+            self._stop_flag.wait(
+                min(self._reconnect_delay(idle_rounds), MAX_FALLBACK_POLL_SECONDS)
+            )
 
             if tracker.maybe_flush(handler):
                 self._stop_flag.set()
@@ -654,6 +709,13 @@ class SSHMessageReader(PipesMessageReader):
             List of command arguments for subprocess.Popen
 
         """
+        control_path = self.control_path
+
+        # Without a master, password auth would need an interactive prompt per
+        # reconnect; polling through the pool is cheaper and non-interactive.
+        if not control_path and self._requires_password_auth() and self._ssh_pool:
+            return None
+
         base_cmd = [
             "ssh",
             *self.ssh_config.get_common_ssh_opts(
@@ -662,24 +724,23 @@ class SSHMessageReader(PipesMessageReader):
             ),
             "-p",
             str(self.ssh_config.port),
+            # Reuse the pool's master when healthy, otherwise attach to (or
+            # start) the shared socket instead of opening a private connection.
+            *self.ssh_config.get_multiplexing_opts(
+                create=control_path is None,
+                control_path=control_path,
+            ),
         ]
 
-        # Use ControlMaster if available (required for password auth)
-        if self.control_path:
-            base_cmd.extend(
-                [
-                    "-o",
-                    f"ControlPath={self.control_path}",
-                    "-o",
-                    "ControlMaster=no",
-                ]
-            )
-            base_cmd.extend(self.ssh_config.get_key_auth_opts())
-            self.logger.debug(f"Using ControlMaster: {self.control_path}")
-        else:
-            if self._requires_password_auth() and self._ssh_pool:
-                return None
-            base_cmd.extend(self.ssh_config.get_auth_opts())
+        # ProxyJump options were previously omitted here, so jump-host setups
+        # bypassed the bastion entirely once the master was unavailable.
+        base_cmd.extend(self.ssh_config.get_proxy_command_opts())
+
+        # Covers key, password and inherited auth, and honours batch_mode.
+        base_cmd.extend(self.ssh_config.get_auth_opts())
+
+        if control_path:
+            self.logger.debug(f"Using ControlMaster: {control_path}")
 
         # Add target
         base_cmd.append(f"{self.ssh_config.user}@{self.ssh_config.host}")

--- a/projects/dagster-slurm/dagster_slurm/helpers/ssh_control.py
+++ b/projects/dagster-slurm/dagster_slurm/helpers/ssh_control.py
@@ -1,0 +1,119 @@
+"""Shared SSH ControlMaster conventions.
+
+HPC login nodes rate-limit (and increasingly ban) accounts that open a fresh
+TCP connection, key exchange and authentication for every remote command.
+Slurm supervision is inherently chatty - status polling, log tailing, Pipes
+message reading - so every SSH and SCP invocation in this package must share a
+single multiplexed connection per ``(user, host, port)``.
+
+This module owns the socket naming so that the connection pool, one-off helper
+commands and long-running ``tail`` processes all point at the *same* socket.
+A per-process random socket name would technically enable multiplexing while
+still paying a full handshake per Dagster step, per sensor tick and per
+process - exactly the behaviour cluster operators complain about.
+
+Environment overrides:
+
+- ``DAGSTER_SLURM_SSH_CONTROL_DIR``: directory holding the control sockets
+  (default ``~/.ssh/dagster-slurm``).
+- ``DAGSTER_SLURM_SSH_CONTROL_PERSIST``: OpenSSH ``ControlPersist`` value kept
+  after the last client detaches (default ``10m``).
+"""
+
+import hashlib
+import os
+from pathlib import Path
+from typing import Optional
+
+CONTROL_DIR_ENV = "DAGSTER_SLURM_SSH_CONTROL_DIR"
+CONTROL_PERSIST_ENV = "DAGSTER_SLURM_SSH_CONTROL_PERSIST"
+
+DEFAULT_CONTROL_DIR = "~/.ssh/dagster-slurm"
+DEFAULT_CONTROL_PERSIST = "10m"
+
+# AF_UNIX socket paths are capped near 104 bytes on macOS and 108 on Linux.
+# Stay well below the lower bound so OpenSSH never silently refuses the socket.
+MAX_CONTROL_PATH_LENGTH = 100
+
+_control_dir_ready: set[str] = set()
+
+
+def control_persist_value() -> str:
+    """Return the configured ``ControlPersist`` value."""
+    value = os.getenv(CONTROL_PERSIST_ENV, "").strip()
+    return value or DEFAULT_CONTROL_PERSIST
+
+
+def control_dir() -> Path:
+    """Return the directory that holds ControlMaster sockets."""
+    configured = os.getenv(CONTROL_DIR_ENV, "").strip()
+    return Path(configured or DEFAULT_CONTROL_DIR).expanduser()
+
+
+def ensure_control_dir() -> Optional[Path]:
+    """Create the control socket directory with private permissions.
+
+    Returns:
+        The directory, or None when it could not be prepared.
+
+    """
+    directory = control_dir()
+    key = str(directory)
+    if key in _control_dir_ready:
+        return directory
+
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+        os.chmod(directory, 0o700)
+    except OSError:
+        return None
+
+    _control_dir_ready.add(key)
+    return directory
+
+
+def control_socket_path(user: str, host: str, port: int) -> Optional[str]:
+    """Return the deterministic control socket path for a connection target.
+
+    The same target always maps to the same socket, so a master started by one
+    Dagster step, sensor tick or process is reused by every later command
+    instead of triggering another handshake.
+    """
+    directory = ensure_control_dir()
+    if directory is None:
+        return None
+
+    target = f"{user}@{host}:{port}"
+    path = directory / f"cm-{target}"
+    if len(str(path)) >= MAX_CONTROL_PATH_LENGTH:
+        digest = hashlib.sha256(target.encode()).hexdigest()[:16]
+        path = directory / f"cm-{digest}"
+    if len(str(path)) >= MAX_CONTROL_PATH_LENGTH:
+        return None
+
+    return str(path)
+
+
+def multiplexing_opts(control_path: Optional[str], *, create: bool) -> list[str]:
+    """Build OpenSSH options that attach a command to the shared control socket.
+
+    Args:
+        control_path: Socket path, or None to disable multiplexing.
+        create: When True the command may promote itself to master if no master
+            is running yet (``ControlMaster=auto``). Use False for commands
+            issued by :class:`~dagster_slurm.helpers.ssh_pool.SSHConnectionPool`,
+            which manages the master explicitly.
+
+    """
+    if not control_path:
+        return []
+
+    opts = [
+        "-o",
+        f"ControlPath={control_path}",
+        "-o",
+        f"ControlMaster={'auto' if create else 'no'}",
+    ]
+    if create:
+        opts.extend(["-o", f"ControlPersist={control_persist_value()}"])
+    return opts

--- a/projects/dagster-slurm/dagster_slurm/helpers/ssh_control.py
+++ b/projects/dagster-slurm/dagster_slurm/helpers/ssh_control.py
@@ -25,6 +25,8 @@ import os
 from pathlib import Path
 from typing import Optional
 
+from dagster import get_dagster_logger
+
 CONTROL_DIR_ENV = "DAGSTER_SLURM_SSH_CONTROL_DIR"
 CONTROL_PERSIST_ENV = "DAGSTER_SLURM_SSH_CONTROL_PERSIST"
 
@@ -34,6 +36,11 @@ DEFAULT_CONTROL_PERSIST = "10m"
 # AF_UNIX socket paths are capped near 104 bytes on macOS and 108 on Linux.
 # Stay well below the lower bound so OpenSSH never silently refuses the socket.
 MAX_CONTROL_PATH_LENGTH = 100
+
+#: Hex characters kept from the target digest when the readable socket name is
+#: too long. 48 bits is far more than enough to keep distinct hosts apart, and
+#: a shorter name leaves more headroom for deep control directories.
+DIGEST_LENGTH = 12
 
 _control_dir_ready: set[str] = set()
 
@@ -81,14 +88,34 @@ def control_socket_path(user: str, host: str, port: int) -> Optional[str]:
     """
     directory = ensure_control_dir()
     if directory is None:
+        get_dagster_logger().warning(
+            "Could not prepare the SSH control directory %s, so connections to "
+            "%s@%s cannot be multiplexed. Set %s to a writable directory.",
+            control_dir(),
+            user,
+            host,
+            CONTROL_DIR_ENV,
+        )
         return None
 
     target = f"{user}@{host}:{port}"
     path = directory / f"cm-{target}"
     if len(str(path)) >= MAX_CONTROL_PATH_LENGTH:
-        digest = hashlib.sha256(target.encode()).hexdigest()[:16]
+        digest = hashlib.sha256(target.encode()).hexdigest()[:DIGEST_LENGTH]
         path = directory / f"cm-{digest}"
     if len(str(path)) >= MAX_CONTROL_PATH_LENGTH:
+        # Silently giving up here would disable multiplexing exactly where it
+        # is hardest to notice, so say so instead.
+        get_dagster_logger().warning(
+            "SSH control socket path would exceed %s characters under %s, so "
+            "connections to %s@%s cannot be multiplexed. Point %s at a shorter "
+            "directory path.",
+            MAX_CONTROL_PATH_LENGTH,
+            directory,
+            user,
+            host,
+            CONTROL_DIR_ENV,
+        )
         return None
 
     return str(path)

--- a/projects/dagster-slurm/dagster_slurm/helpers/ssh_helpers.py
+++ b/projects/dagster-slurm/dagster_slurm/helpers/ssh_helpers.py
@@ -45,10 +45,13 @@ def normalize_slurm_state(state: str) -> str:
 
 
 def ssh_run(cmd: str, ssh_resource) -> tuple[str, str, int]:
-    """Run SSH command via connection pool, return (stdout, stderr, returncode).
+    """Run a one-off SSH command, returning (stdout, stderr, returncode).
 
-    Note: This is a legacy function for compatibility.
-    New code should use SSHConnectionPool directly.
+    The command joins the shared ControlMaster socket via
+    ``get_ssh_base_command``, so it reuses an existing master and starts one if
+    none is running. Note: this is a legacy helper kept for compatibility. New
+    code should use SSHConnectionPool directly, which also health-checks the
+    master.
     """
     import shlex
     import subprocess

--- a/projects/dagster-slurm/dagster_slurm/helpers/ssh_pool.py
+++ b/projects/dagster-slurm/dagster_slurm/helpers/ssh_pool.py
@@ -4,12 +4,15 @@ import os
 import shlex
 import subprocess
 import threading
+import time
 import uuid
 from pathlib import Path
 from typing import Callable, Optional, Pattern, Union, cast
 
 from dagster import get_dagster_logger
 from typing import TYPE_CHECKING
+
+from .ssh_control import control_persist_value, control_socket_path
 
 if TYPE_CHECKING:
     from ..resources.ssh import SSHConnectionResource
@@ -35,22 +38,38 @@ MULTIPLEXING_UNSUPPORTED_MESSAGE = (
 
 class SSHConnectionPool:
     """Reuse SSH connections via ControlMaster.
-    Supports both key-based and password-based authentication.
-    Password-based auth uses SSH_ASKPASS for secure password handling.
+
+    The control socket is derived deterministically from ``user@host:port``
+    (see :mod:`dagster_slurm.helpers.ssh_control`), so a master started by one
+    Dagster step, sensor tick or process is reused by all later ones instead of
+    triggering another DNS lookup, TCP handshake and authentication.
+
+    The master is health-checked before use. OpenSSH silently opens a *full*
+    connection when a ``ControlPath`` socket is stale, which would otherwise
+    turn a one-second Slurm polling loop into thousands of handshakes per hour
+    while the pool still reported multiplexing as healthy.
+
+    Supports both key-based and password-based authentication. Password-based
+    auth cannot be multiplexed and always uses one-off connections.
     """
 
-    _CONTROL_DIR_ENV = "DAGSTER_SLURM_SSH_CONTROL_DIR"
-    _DEFAULT_CONTROL_DIR = Path("~/.ssh/dagster-slurm").expanduser()
+    _CLOSE_MASTER_ENV = "DAGSTER_SLURM_SSH_CLOSE_MASTER_ON_EXIT"
+
+    #: Minimum seconds between two ``ssh -O check`` probes of the master.
+    MASTER_CHECK_INTERVAL_SECONDS = 15.0
 
     def __init__(self, ssh_config: "SSHConnectionResource"):
         self.config = ssh_config
         self.logger = get_dagster_logger()
         self.control_path: Optional[str] = self._prepare_control_path()
         self._master_started = False
+        self._owns_master = False
         self._fallback_mode = False
         self._fallback_reason: Optional[str] = None
-        self._fallback_unsupported = False
         self._lock = threading.RLock()
+        self._depth = 0
+        self._last_master_check = 0.0
+        self._fallback_unsupported = False
         #: Optional (level, message) sink. When unset the pool logs the state
         #: itself, so every caller - sensors, session and hetjob setup included
         #: - reports it without having to remember to.
@@ -65,32 +84,18 @@ class SSHConnectionPool:
         return passwords
 
     def _prepare_control_path(self) -> Optional[str]:
-        """Return a secure path for the ControlMaster socket or None on failure."""
-        base_dir = os.getenv(self._CONTROL_DIR_ENV)
-        if base_dir:
-            control_dir = Path(base_dir).expanduser()
-        else:
-            control_dir = self._DEFAULT_CONTROL_DIR
-
-        try:
-            control_dir.mkdir(parents=True, exist_ok=True)
-            os.chmod(control_dir, 0o700)
-        except Exception as exc:  # pragma: no cover - best effort
-            self.logger.warning(
-                "Could not prepare SSH control directory %s (%s). "
-                "Falling back to non-pooled SSH connections.",
-                control_dir,
-                exc,
-            )
+        """Return the shared ControlMaster socket path, or None when unusable."""
+        if not self.config.supports_multiplexing:
             return None
 
-        socket_name = f"cm-{uuid.uuid4().hex[:12]}"
-        control_path = control_dir / socket_name
-
-        if len(str(control_path)) >= 100:
-            control_path = control_dir / socket_name[:8]
-
-        return str(control_path)
+        path = control_socket_path(self.config.user, self.config.host, self.config.port)
+        if path is None:
+            self.logger.warning(
+                "Could not prepare the SSH control directory for %s. "
+                "Falling back to non-pooled SSH connections.",
+                self.config.host,
+            )
+        return path
 
     @property
     def multiplexing_active(self) -> bool:
@@ -101,6 +106,79 @@ class SSHConnectionPool:
     def fallback_reason(self) -> str | None:
         """Why the pool is using one-off SSH connections, if known."""
         return self._fallback_reason
+
+    def _multiplexing_opts(self) -> list[str]:
+        """ControlMaster options for a command issued through this pool."""
+        return self.config.get_multiplexing_opts(
+            create=False, control_path=self.control_path
+        )
+
+    def _master_is_alive(self) -> bool:
+        """Ask OpenSSH whether the control socket has a live master behind it.
+
+        ``ssh -O check`` only talks to the local unix socket, so this is cheap
+        and never creates a network connection.
+        """
+        if not self.control_path:
+            return False
+
+        try:
+            completed = subprocess.run(
+                [
+                    "ssh",
+                    "-O",
+                    "check",
+                    "-o",
+                    f"ControlPath={self.control_path}",
+                    f"{self.config.user}@{self.config.host}",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except Exception:  # pragma: no cover - best effort probe
+            return False
+
+        return completed.returncode == 0
+
+    def _spawn_master(self) -> None:
+        """Start a background ControlMaster, raising on failure."""
+        cmd = [
+            "ssh",
+            # Keepalives matter: without them an idle NAT or firewall silently
+            # drops the master and every later command reconnects on its own.
+            *self.config.get_common_ssh_opts(
+                server_alive_interval=30,
+                server_alive_count_max=6,
+            ),
+            "-M",
+            "-N",
+            "-f",
+            "-p",
+            str(self.config.port),
+            "-o",
+            f"ControlPath={self.control_path}",
+            "-o",
+            f"ControlPersist={control_persist_value()}",
+        ]
+        cmd.extend(self.config.get_proxy_command_opts())
+        cmd.extend(self.config.get_key_auth_opts())
+        cmd.append(f"{self.config.user}@{self.config.host}")
+
+        completed = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        if completed.returncode != 0:
+            # Another process may have won the race for the same socket.
+            if self._master_is_alive():
+                self._owns_master = False
+                return
+            stderr = completed.stderr
+            raise RuntimeError(
+                "Failed to start SSH master: "
+                f"{stderr.strip()}{self.config.host_key_error_hint(stderr)}"
+                f"{self.config.auth_error_hint(stderr)}"
+            )
+
+        self._owns_master = True
 
     @property
     def multiplexing_unsupported(self) -> bool:
@@ -146,87 +224,100 @@ class SSHConnectionPool:
         else:
             self.logger.warning(message)
 
-    def __enter__(self):
-        """Start SSH ControlMaster."""
+    def _enter_fallback(self, reason: str, *, unsupported: bool = False) -> None:
+        """Switch to one-off connections, record why, and say so."""
+        self._fallback_mode = True
+        self._fallback_reason = reason
+        self._fallback_unsupported = unsupported
+        self.control_path = None
+        self._report_multiplexing_state()
+
+    def _start_master(self) -> None:
+        """Reuse a live ControlMaster or start a new one."""
         self.logger.debug("Starting SSH ControlMaster...")
 
-        if not self.control_path:
-            self.logger.debug(
-                "Control path unavailable; using direct SSH connections for %s",
-                self.config.host,
-            )
-            self._fallback_mode = True
-            self._fallback_reason = "SSH control socket path is unavailable"
-            self._report_multiplexing_state()
-            return self
-
-        if self.config.uses_password_auth or (
-            self.config.jump_host and self.config.jump_host.uses_password_auth
-        ):
+        unsupported_reason = self.config.multiplexing_unsupported_reason
+        if unsupported_reason:
             self.logger.debug(
                 "ControlMaster disabled for %s because password-based or jump-host "
                 "authentication is in use.",
                 self.config.host,
             )
-            self._fallback_mode = True
-            self._fallback_unsupported = True
-            self._fallback_reason = "password-based authentication is configured for the target or jump host"
-            self.control_path = None
-            self._report_multiplexing_state()
-            return self
+            self._enter_fallback(unsupported_reason, unsupported=True)
+            return
 
-        # Build master connection command
-        base_opts = [
-            "-o",
-            f"ControlPath={self.control_path}",
-            "-o",
-            "ControlPersist=10m",
-        ]
+        if not self.control_path:
+            self._enter_fallback("SSH control socket path is unavailable")
+            return
+
+        if self._master_is_alive():
+            self._master_started = True
+            self._owns_master = False
+            self._last_master_check = time.monotonic()
+            self.logger.debug(
+                "Reusing existing SSH ControlMaster at %s", self.control_path
+            )
+            return
 
         try:
-            cmd = [
-                "ssh",
-                *self.config.get_common_ssh_opts(),
-                "-M",
-                "-N",
-                "-f",
-                "-p",
-                str(self.config.port),
-            ]
-            cmd.extend(base_opts)
-            cmd.extend(self.config.get_proxy_command_opts())
-            cmd.extend(self.config.get_key_auth_opts())
-            cmd.append(f"{self.config.user}@{self.config.host}")
-
-            if self.config.uses_password_auth or (
-                self.config.jump_host and self.config.jump_host.uses_password_auth
-            ):
-                result = self._run_with_password(cmd, self._collect_passwords(), 30)
-                returncode = result.returncode
-                stderr = result.stderr
-            else:
-                completed = subprocess.run(
-                    cmd, capture_output=True, text=True, timeout=30
-                )
-                returncode = completed.returncode
-                stderr = completed.stderr
-
-            if returncode != 0:
-                raise RuntimeError(
-                    "Failed to start SSH master: "
-                    f"{stderr.strip()}{self.config.host_key_error_hint(stderr)}{self.config.auth_error_hint(stderr)}"
-                )
-
-            self._master_started = True
-            auth_method = "key" if self.config.uses_key_auth else "inherited"
-            self.logger.debug(f"SSH ControlMaster started ({auth_method} auth)")
+            self._spawn_master()
         except Exception as exc:
-            self._fallback_mode = True
-            self._fallback_reason = str(exc)
-            self.control_path = None
-            self._report_multiplexing_state()
+            self._enter_fallback(str(exc))
+            return
 
-        return self
+        self._master_started = True
+        self._last_master_check = time.monotonic()
+        auth_method = "key" if self.config.uses_key_auth else "inherited"
+        self.logger.debug(f"SSH ControlMaster started ({auth_method} auth)")
+
+    def _ensure_master_alive(self, *, force: bool = False) -> None:
+        """Re-check and, if needed, restart the master before running a command.
+
+        Without this a dead socket degrades silently: OpenSSH just opens a full
+        connection per command and reports success.
+        """
+        if not self._master_started or self._fallback_mode:
+            return
+
+        now = time.monotonic()
+        if (
+            not force
+            and now - self._last_master_check < self.MASTER_CHECK_INTERVAL_SECONDS
+        ):
+            return
+
+        self._last_master_check = now
+        if self._master_is_alive():
+            return
+
+        self.logger.warning(
+            "SSH ControlMaster for %s is gone; restarting it before continuing.",
+            self.config.host,
+        )
+        try:
+            self._spawn_master()
+        except Exception as exc:
+            self._enter_fallback(
+                f"ControlMaster died mid-run and could not be restarted: {exc}"
+            )
+            return
+
+        self._last_master_check = time.monotonic()
+        self.logger.info("SSH ControlMaster for %s restarted.", self.config.host)
+
+    def __enter__(self):
+        """Start (or attach to) the shared SSH ControlMaster."""
+        with self._lock:
+            self._depth += 1
+            if self._depth > 1:
+                # Nested/re-entered context: the master is already set up.
+                return self
+            if self._master_started and not self._fallback_mode:
+                # Re-entering a pool whose master was intentionally left alive.
+                self._ensure_master_alive(force=True)
+                return self
+            self._start_master()
+            return self
 
     def _run_with_password(self, cmd, password, timeout=30):
         """Run SSH command with password using pexpect."""
@@ -319,9 +410,19 @@ class SSHConnectionPool:
         except pexpect.exceptions.ExceptionPexpect as e:
             raise RuntimeError(f"Password authentication failed: {e}")
 
-    def __exit__(self, *args):
-        """Close master connection."""
-        if self._master_started and not self._fallback_mode:
+    def _should_close_master(self) -> bool:
+        """Whether to tear the master down instead of leaving it for reuse."""
+        return os.getenv(self._CLOSE_MASTER_ENV, "").strip().lower() in {
+            "1",
+            "true",
+            "yes",
+        }
+
+    def close_master(self) -> None:
+        """Terminate the shared ControlMaster immediately."""
+        with self._lock:
+            if not (self._master_started and not self._fallback_mode):
+                return
             try:
                 subprocess.run(
                     [
@@ -338,6 +439,24 @@ class SSHConnectionPool:
                 self.logger.debug("SSH ControlMaster closed")
             except Exception as e:
                 self.logger.warning(f"Error closing SSH master: {e}")
+            finally:
+                self._master_started = False
+                self._owns_master = False
+
+    def __exit__(self, *args):
+        """Detach from the master, leaving it alive for the next caller.
+
+        Tearing the master down here would make ``ControlPersist`` pointless:
+        the next Dagster step or sensor tick would pay another full handshake.
+        Set ``DAGSTER_SLURM_SSH_CLOSE_MASTER_ON_EXIT=1`` to restore the old
+        eager-shutdown behaviour.
+        """
+        with self._lock:
+            self._depth = max(0, self._depth - 1)
+            if self._depth > 0:
+                return
+            if self._should_close_master():
+                self.close_master()
 
     def run(self, cmd: str, timeout: Optional[int] = None) -> str:
         """Run command using pooled connection.
@@ -357,6 +476,8 @@ class SSHConnectionPool:
             if not self._master_started and not self._fallback_mode:
                 raise RuntimeError("SSH pool not started - use context manager")
 
+            self._ensure_master_alive()
+
             # Wrap in clean shell
             remote_cmd = f"bash --noprofile --norc -c {shlex.quote(cmd)}"
             if self.config.post_login_command:
@@ -374,10 +495,7 @@ class SSHConnectionPool:
                     *self.config.get_common_ssh_opts(),
                     "-p",
                     str(self.config.port),
-                    "-o",
-                    f"ControlPath={self.control_path}",
-                    "-o",
-                    "ControlMaster=no",
+                    *self._multiplexing_opts(),
                 ]
                 ssh_cmd.extend(self.config.get_key_auth_opts())
                 if needs_tty:
@@ -483,6 +601,8 @@ class SSHConnectionPool:
 
         # Build SCP command
         with self._lock:
+            self._ensure_master_alive()
+
             if self._master_started and not self._fallback_mode:
                 scp_cmd = [
                     "scp",
@@ -490,10 +610,7 @@ class SSHConnectionPool:
                     "-C",  # Enable compression (critical for large files!)
                     "-P",
                     str(self.config.port),
-                    "-o",
-                    f"ControlPath={self.control_path}",
-                    "-o",
-                    "ControlMaster=no",
+                    *self._multiplexing_opts(),
                 ]
                 scp_cmd.extend(self.config.get_key_auth_opts())
             else:

--- a/projects/dagster-slurm/dagster_slurm/pipes_clients/slurm_pipes_client.py
+++ b/projects/dagster-slurm/dagster_slurm/pipes_clients/slurm_pipes_client.py
@@ -1099,6 +1099,22 @@ class SlurmPipesClient(PipesClient):
         state = self._get_job_state(job_id, ssh_pool)
         return state in {"PENDING", "RUNNING", "CONFIGURING", "COMPLETING"}
 
+    @staticmethod
+    def _bounded_poll_sleep(
+        poll_interval: float, elapsed: float, poll_timeout: float
+    ) -> float:
+        """Clamp a polling sleep so it cannot overshoot the deadline.
+
+        Backing off is only safe if the loop still gets a look at the job just
+        before poll_timeout. Otherwise a job that finished at t=57s with a 60s
+        budget is reported as a timeout it never actually hit, purely because
+        the next poll was scheduled for t=71s.
+        """
+        remaining = poll_timeout - elapsed
+        if remaining <= 0:
+            return 0.0
+        return max(0.1, min(poll_interval, remaining - 0.25))
+
     def _interruptible_sleep(self, seconds: float, job_id: int) -> None:
         """Sleep that catches async DagsterExecutionInterruptedError.
 
@@ -3247,7 +3263,12 @@ exit "$_dagster_slurm_workload_exit"
                         self.logger.debug(
                             f"Job {job_id} is completing, waiting for terminal state..."
                         )
-                        self._interruptible_sleep(poll_interval, job_id)
+                        self._interruptible_sleep(
+                            self._bounded_poll_sleep(
+                                poll_interval, time.time() - start_time, poll_timeout
+                            ),
+                            job_id,
+                        )
                         continue
 
                     if state in TERMINAL_STATES:
@@ -3325,7 +3346,12 @@ exit "$_dagster_slurm_workload_exit"
                         self.logger.info(f"Job {job_id} completed successfully")
                         break
 
-                    self._interruptible_sleep(poll_interval, job_id)
+                    self._interruptible_sleep(
+                        self._bounded_poll_sleep(
+                            poll_interval, time.time() - start_time, poll_timeout
+                        ),
+                        job_id,
+                    )
                     continue
 
                 except Exception as exc:

--- a/projects/dagster-slurm/dagster_slurm/pipes_clients/slurm_pipes_client.py
+++ b/projects/dagster-slurm/dagster_slurm/pipes_clients/slurm_pipes_client.py
@@ -76,6 +76,12 @@ class _JoinableThread(Protocol):
 _TerminableProcessT = TypeVar("_TerminableProcessT", bound=_TerminableProcess)
 
 
+#: Log polling cadence used only when ControlMaster is unavailable and each
+#: round costs a full SSH connection.
+_FALLBACK_STREAM_POLL_SECONDS = 1.0
+_FALLBACK_STREAM_POLL_MAX_SECONDS = 15.0
+
+
 def _remote_join_under_root(root: str, base: str, relative_path: str) -> str:
     """Join a remote path and keep it inside the remote pack workspace root."""
     if posixpath.isabs(relative_path):
@@ -173,7 +179,6 @@ class SlurmPipesClient(PipesClient):
         self.pack_platform = pack_platform
         self.logger = get_dagster_logger()
         self.metrics_collector = SlurmMetricsCollector()
-        self._control_path = None
         self._current_job_id = None
         self._ssh_pool = None
         self._cancellation_requested = False
@@ -283,9 +288,6 @@ class SlurmPipesClient(PipesClient):
 
         try:
             with ssh_pool:
-                # Store control path for log streaming
-                self._control_path = ssh_pool.control_path
-
                 remote_base = self._get_remote_base(run_id, ssh_pool)
                 op_ctx = context.op_execution_context
 
@@ -730,6 +732,16 @@ class SlurmPipesClient(PipesClient):
 
         return PipesClientCompletedInvocation(session)
 
+    @property
+    def _control_path(self) -> Optional[str]:
+        """Live ControlMaster socket, or None once the pool degraded.
+
+        Read through to the pool so log-streaming commands started later never
+        keep pointing at a socket the pool has already abandoned.
+        """
+        pool = self._ssh_pool
+        return getattr(pool, "control_path", None) if pool is not None else None
+
     def _attach_multiplexing_reporter(
         self,
         context: AssetExecutionContext,
@@ -739,8 +751,8 @@ class SlurmPipesClient(PipesClient):
 
         The pool reports the state itself, so sensors, session setup and hetjob
         submission are covered without repeating this call. Attaching a reporter
-        only changes *where* the message goes, so a run sees it on the step
-        rather than only in the daemon log.
+        only changes *where* the message goes - including a master lost mid-run,
+        which travels the same path as one that never started.
         """
         if not hasattr(ssh_pool, "reporter"):
             return
@@ -2972,6 +2984,9 @@ exit "$_dagster_slurm_workload_exit"
                 if tail_cmd is None:
                     next_line = 1
                     quoted_path = shlex.quote(remote_path)
+                    # Every poll is a full SSH connection in this mode, so an
+                    # idle log file must not be polled once per second.
+                    poll_interval = _FALLBACK_STREAM_POLL_SECONDS
                     self.logger.debug(
                         "Streaming %s via polling fallback (ControlMaster unavailable)",
                         remote_path,
@@ -2990,22 +3005,26 @@ exit "$_dagster_slurm_workload_exit"
                                 )
                             break
 
-                        if output:
-                            lines = output.splitlines()
-                            if lines:
-                                for line in lines:
-                                    if not line.strip():
-                                        continue
-                                    dashboard_log_emitter.process_line(line)
-                                    output_stream.write(f"{prefix}{line}\n")
-                                output_stream.flush()
-                                with streamed_lock:
-                                    streamed_lines[stream_key] += sum(
-                                        1 for line in lines if line.strip()
-                                    )
-                                next_line += len(lines)
+                        lines = output.splitlines() if output else []
+                        if lines:
+                            for line in lines:
+                                if not line.strip():
+                                    continue
+                                dashboard_log_emitter.process_line(line)
+                                output_stream.write(f"{prefix}{line}\n")
+                            output_stream.flush()
+                            with streamed_lock:
+                                streamed_lines[stream_key] += sum(
+                                    1 for line in lines if line.strip()
+                                )
+                            next_line += len(lines)
+                            poll_interval = _FALLBACK_STREAM_POLL_SECONDS
+                        else:
+                            poll_interval = min(
+                                poll_interval * 2, _FALLBACK_STREAM_POLL_MAX_SECONDS
+                            )
 
-                        stop_streaming.wait(1.0)
+                        stop_streaming.wait(poll_interval)
                     return
 
                 with stream_processes_lock:
@@ -3063,6 +3082,10 @@ exit "$_dagster_slurm_workload_exit"
         start_time = time.time()
         last_state = None
         state_check_count = 0
+        # Status polling costs one SSH command plus a squeue/sacct query per
+        # round. Start gently and back off while nothing changes; any state
+        # transition resets the cadence so completion is still noticed quickly.
+        poll_interval = self.slurm.status_poll_interval_seconds
 
         # Poll job status.
         # The outer try/finally handles cleanup.  Each iteration of the
@@ -3130,8 +3153,12 @@ exit "$_dagster_slurm_workload_exit"
                             )
                         last_state = state
                         state_check_count = 0
+                        poll_interval = self.slurm.status_poll_interval_seconds
                     else:
                         state_check_count += 1
+                        poll_interval = self.slurm.next_status_poll_interval(
+                            poll_interval
+                        )
 
                     # Handle empty state
                     if not state:
@@ -3220,7 +3247,7 @@ exit "$_dagster_slurm_workload_exit"
                         self.logger.debug(
                             f"Job {job_id} is completing, waiting for terminal state..."
                         )
-                        self._interruptible_sleep(1, job_id)
+                        self._interruptible_sleep(poll_interval, job_id)
                         continue
 
                     if state in TERMINAL_STATES:
@@ -3298,7 +3325,7 @@ exit "$_dagster_slurm_workload_exit"
                         self.logger.info(f"Job {job_id} completed successfully")
                         break
 
-                    self._interruptible_sleep(1, job_id)
+                    self._interruptible_sleep(poll_interval, job_id)
                     continue
 
                 except Exception as exc:
@@ -3429,29 +3456,30 @@ exit "$_dagster_slurm_workload_exit"
             if requires_password or jump_requires_password:
                 return None
 
+        control_path = self._control_path
         cmd = [
             "ssh",
-            *self.slurm.ssh.get_common_ssh_opts(),
+            # A `tail -F` connection idles between log lines; without keepalives
+            # a firewall can drop it and force an endless reconnect loop.
+            *self.slurm.ssh.get_common_ssh_opts(
+                server_alive_interval=30,
+                server_alive_count_max=6,
+            ),
             "-p",
             str(self.slurm.ssh.port),
+            # Share the pool's master when it is healthy, otherwise attach to
+            # (or start) the shared socket rather than opening a private one.
+            *self.slurm.ssh.get_multiplexing_opts(
+                create=control_path is None,
+                control_path=control_path,
+            ),
         ]
 
         # Include proxy jump options if configured
         cmd.extend(self.slurm.ssh.get_proxy_command_opts())
 
-        # Use ControlMaster if available
-        if self._control_path:
-            cmd.extend(
-                [
-                    "-o",
-                    f"ControlPath={self._control_path}",
-                    "-o",
-                    "ControlMaster=no",
-                ]
-            )
-            cmd.extend(self.slurm.ssh.get_key_auth_opts())
-        else:
-            cmd.extend(self.slurm.ssh.get_auth_opts())
+        # ControlMaster options are already set above; only auth is left.
+        cmd.extend(self.slurm.ssh.get_auth_opts())
 
         cmd.append(f"{self.slurm.ssh.user}@{self.slurm.ssh.host}")
 

--- a/projects/dagster-slurm/dagster_slurm/resources/slurm.py
+++ b/projects/dagster-slurm/dagster_slurm/resources/slurm.py
@@ -19,6 +19,25 @@ _SLURM_TIME_LIMIT_RE = re.compile(
 )
 
 
+def _status_poll_env() -> dict[str, float]:
+    """Read Slurm status polling cadence overrides from the environment."""
+    env_by_field = {
+        "status_poll_interval_seconds": "SLURM_STATUS_POLL_INTERVAL",
+        "status_poll_max_interval_seconds": "SLURM_STATUS_POLL_MAX_INTERVAL",
+        "status_poll_backoff_factor": "SLURM_STATUS_POLL_BACKOFF",
+    }
+    overrides: dict[str, float] = {}
+    for field, var_name in env_by_field.items():
+        raw = os.getenv(var_name, "").strip()
+        if not raw:
+            continue
+        try:
+            overrides[field] = float(raw)
+        except ValueError:
+            raise ValueError(f"{var_name} must be a number, got: {raw!r}") from None
+    return overrides
+
+
 def _optional_env(var_name: str, default: Optional[str] = None) -> Optional[str]:
     """Return an optional string from the environment.
 
@@ -161,7 +180,45 @@ class SlurmResource(ConfigurableResource):
         default=None,
         description="Base directory on remote system (default: ~/pipelines/<run_id>)",
     )
+    status_poll_interval_seconds: float = Field(
+        default=2.0,
+        gt=0,
+        description=(
+            "Seconds between the first Slurm status checks of a job. Each check "
+            "is an SSH command plus a squeue/sacct query on the login node, so "
+            "HPC sites usually ask for more than one per second."
+        ),
+    )
+    status_poll_max_interval_seconds: float = Field(
+        default=15.0,
+        gt=0,
+        description=(
+            "Upper bound for the status polling interval. The interval grows "
+            "while the job state stays unchanged and resets on every change."
+        ),
+    )
+    status_poll_backoff_factor: float = Field(
+        default=1.5,
+        ge=1.0,
+        description="Growth factor applied to the status polling interval.",
+    )
     _auth_provider: Optional[object] = PrivateAttr(default=None)
+
+    @model_validator(mode="after")
+    def _validate_status_polling(self) -> "SlurmResource":
+        if self.status_poll_max_interval_seconds < self.status_poll_interval_seconds:
+            raise ValueError(
+                "status_poll_max_interval_seconds must be >= "
+                "status_poll_interval_seconds"
+            )
+        return self
+
+    def next_status_poll_interval(self, current: float) -> float:
+        """Return the next status polling interval after an unchanged state."""
+        return min(
+            current * self.status_poll_backoff_factor,
+            self.status_poll_max_interval_seconds,
+        )
 
     def set_auth_provider(self, provider: object) -> "SlurmResource":
         self._auth_provider = provider
@@ -194,6 +251,7 @@ class SlurmResource(ConfigurableResource):
                 signal_before_timeout=_optional_env("SLURM_SIGNAL_BEFORE_TIMEOUT"),
             ),
             remote_base=os.getenv("SLURM_REMOTE_BASE", "/home/submitter"),
+            **_status_poll_env(),
         )
 
     @classmethod
@@ -215,4 +273,5 @@ class SlurmResource(ConfigurableResource):
                 signal_before_timeout=_optional_env("SLURM_SIGNAL_BEFORE_TIMEOUT"),
             ),
             remote_base=os.getenv("SLURM_REMOTE_BASE", "/home/submitter"),
+            **_status_poll_env(),
         )

--- a/projects/dagster-slurm/dagster_slurm/resources/slurm.py
+++ b/projects/dagster-slurm/dagster_slurm/resources/slurm.py
@@ -190,7 +190,7 @@ class SlurmResource(ConfigurableResource):
         ),
     )
     status_poll_max_interval_seconds: float = Field(
-        default=15.0,
+        default=5.0,
         gt=0,
         description=(
             "Upper bound for the status polling interval. The interval grows "

--- a/projects/dagster-slurm/dagster_slurm/resources/ssh.py
+++ b/projects/dagster-slurm/dagster_slurm/resources/ssh.py
@@ -8,6 +8,8 @@ from typing import Literal
 from dagster import ConfigurableResource
 from pydantic import Field, field_validator, model_validator
 
+from ..helpers.ssh_control import control_socket_path, multiplexing_opts
+
 HostKeyChecking = Literal["off", "accept-new", "strict", "inherit"]
 
 
@@ -204,6 +206,50 @@ class SSHConnectionResource(ConfigurableResource):
         )
 
     @property
+    def supports_multiplexing(self) -> bool:
+        """Whether SSH ControlMaster can be used for this connection.
+
+        Password prompts cannot be answered by a multiplexed client, so
+        interactive authentication (on the target or on the jump host) forces
+        one-off connections.
+        """
+        if self.uses_password_auth:
+            return False
+        if self.jump_host and self.jump_host.uses_password_auth:
+            return False
+        return True
+
+    @property
+    def multiplexing_unsupported_reason(self) -> str | None:
+        """Explain why ControlMaster is unavailable, if it is."""
+        if self.supports_multiplexing:
+            return None
+        return "password-based authentication is configured for the target or jump host"
+
+    def control_socket_path(self) -> str | None:
+        """Return the shared ControlMaster socket path for this connection."""
+        if not self.supports_multiplexing:
+            return None
+        return control_socket_path(self.user, self.host, self.port)
+
+    def get_multiplexing_opts(
+        self,
+        *,
+        create: bool = True,
+        control_path: str | None = None,
+    ) -> list[str]:
+        """Build ControlMaster options pointing at the shared control socket.
+
+        Args:
+            create: Allow the command to become the master when none exists.
+                Callers that manage the master themselves pass False.
+            control_path: Override the socket path (used by the connection pool).
+
+        """
+        path = control_path if control_path is not None else self.control_socket_path()
+        return multiplexing_opts(path, create=create)
+
+    @property
     def requires_tty(self) -> bool:
         """Return True when the resource explicitly requires a TTY."""
         if self.force_tty:
@@ -317,6 +363,9 @@ class SSHConnectionResource(ConfigurableResource):
         command = [
             "ssh",
             *jump.get_common_ssh_opts(),
+            # Multiplex the jump hop as well, otherwise every fallback command
+            # re-authenticates against the bastion.
+            *jump.get_multiplexing_opts(create=True),
             "-p",
             str(jump.port),
             *jump.get_key_auth_opts(),
@@ -508,6 +557,9 @@ class SSHConnectionResource(ConfigurableResource):
         return [
             "ssh",
             *base_opts,
+            # Attach to (or create) the shared control socket so one-off
+            # commands never pay a full handshake of their own.
+            *self.get_multiplexing_opts(create=True),
             *proxy_opts,
             "-p",
             str(self.port),
@@ -523,6 +575,7 @@ class SSHConnectionResource(ConfigurableResource):
         return [
             "scp",
             *base_opts,
+            *self.get_multiplexing_opts(create=True),
             *proxy_opts,
             "-P",
             str(self.port),

--- a/projects/dagster-slurm/dagster_slurm_test/conftest.py
+++ b/projects/dagster-slurm/dagster_slurm_test/conftest.py
@@ -1,9 +1,10 @@
 """Pytest configuration and fixtures."""
 
 import os
+import shutil
 import tempfile
 from pathlib import Path
-from typing import Type
+from typing import Iterator, Type
 import base64
 
 
@@ -94,6 +95,30 @@ def _prepare_docker_slurm_paths():
         capture_output=True,
         text=True,
     )
+
+
+@pytest.fixture(autouse=True)
+def isolated_ssh_control_dir(monkeypatch) -> Iterator[Path]:
+    """Point the SSH control socket directory at a short, per-test path.
+
+    Unix domain sockets cap out near 104 bytes, and pytest's ``tmp_path`` is
+    already ~90 characters deep on CI runners (TMPDIR is /home/runner/work/_temp
+    there, not /tmp). Using it would push every control socket over the limit,
+    silently disabling the multiplexing these tests exist to verify.
+
+    Autouse, so tests that build SSH commands indirectly are covered too and
+    none of them write sockets into the developer's real ~/.ssh/dagster-slurm.
+
+    The base directory is chosen explicitly rather than from TMPDIR, which is
+    itself long on some CI images and would reintroduce the same problem.
+    """
+    base = Path("/tmp") if os.path.isdir("/tmp") else Path(tempfile.gettempdir())
+    directory = Path(tempfile.mkdtemp(prefix="dsctl", dir=str(base)))
+    monkeypatch.setenv("DAGSTER_SLURM_SSH_CONTROL_DIR", str(directory))
+    try:
+        yield directory
+    finally:
+        shutil.rmtree(directory, ignore_errors=True)
 
 
 @pytest.fixture

--- a/projects/dagster-slurm/dagster_slurm_test/test_env_caching.py
+++ b/projects/dagster-slurm/dagster_slurm_test/test_env_caching.py
@@ -39,7 +39,7 @@ class FakePool:
         self.payload_exists = payload_exists
         self.multiplexing_active = True
         self.fallback_reason: str | None = None
-        self.on_multiplexing_lost = None
+        self.reporter = None
 
     def __enter__(self):
         return self

--- a/projects/dagster-slurm/dagster_slurm_test/test_message_readers.py
+++ b/projects/dagster-slurm/dagster_slurm_test/test_message_readers.py
@@ -205,10 +205,9 @@ def test_local_message_reader_uses_configurable_closed_drain_timeout(tmp_path):
 
 
 def test_ssh_message_reader_tail_multiplexes_and_keeps_proxy_jump(
-    monkeypatch, tmp_path
+    isolated_ssh_control_dir, tmp_path
 ):
     """A tail without ControlMaster (or ProxyJump) is a direct login-node hit."""
-    monkeypatch.setenv("DAGSTER_SLURM_SSH_CONTROL_DIR", str(tmp_path / "control"))
 
     jump_key = tmp_path / "jump_key"
     jump_key.write_text("dummy-key")
@@ -233,7 +232,7 @@ def test_ssh_message_reader_tail_multiplexes_and_keeps_proxy_jump(
     joined = " ".join(cmd)
     assert "ProxyCommand=" in joined
     assert "ControlMaster=auto" in joined
-    assert f"ControlPath={tmp_path / 'control'}/cm-" in joined
+    assert f"ControlPath={isolated_ssh_control_dir}/cm-" in joined
 
 
 def test_ssh_message_reader_tracks_the_pool_control_path(tmp_path):

--- a/projects/dagster-slurm/dagster_slurm_test/test_message_readers.py
+++ b/projects/dagster-slurm/dagster_slurm_test/test_message_readers.py
@@ -1,5 +1,7 @@
 import io
 import json
+from types import SimpleNamespace
+from typing import Any, cast
 
 from dagster_slurm.helpers.message_readers import LocalMessageReader, SSHMessageReader
 from dagster_slurm.resources.ssh import SSHConnectionResource
@@ -63,6 +65,10 @@ def test_ssh_message_reader_resumes_after_reconnect(monkeypatch, tmp_path):
         remote_path="/tmp/messages.jsonl",
         ssh_config=ssh_resource,
         max_reconnect_attempts=1,
+        # The fake tail exits instantly; treat that as a healthy session so
+        # these tests exercise resume/close handling rather than the new
+        # flapping-connection backoff.
+        healthy_session_seconds=0.0,
     )
     handler = _CollectingHandler()
 
@@ -125,6 +131,10 @@ def test_ssh_message_reader_tracks_closed_exception(monkeypatch, tmp_path):
         remote_path="/tmp/messages.jsonl",
         ssh_config=ssh_resource,
         max_reconnect_attempts=1,
+        # The fake tail exits instantly; treat that as a healthy session so
+        # these tests exercise resume/close handling rather than the new
+        # flapping-connection backoff.
+        healthy_session_seconds=0.0,
     )
     handler = _CollectingHandler()
 
@@ -192,3 +202,106 @@ def test_local_message_reader_uses_configurable_closed_drain_timeout(tmp_path):
         "opened",
         "closed",
     ]
+
+
+def test_ssh_message_reader_tail_multiplexes_and_keeps_proxy_jump(
+    monkeypatch, tmp_path
+):
+    """A tail without ControlMaster (or ProxyJump) is a direct login-node hit."""
+    monkeypatch.setenv("DAGSTER_SLURM_SSH_CONTROL_DIR", str(tmp_path / "control"))
+
+    jump_key = tmp_path / "jump_key"
+    jump_key.write_text("dummy-key")
+    target_key = tmp_path / "target_key"
+    target_key.write_text("dummy-key")
+
+    jump = SSHConnectionResource(
+        host="jump.example.com", user="jumpuser", key_path=str(jump_key)
+    )
+    target = SSHConnectionResource(
+        host="target.example.com",
+        user="testuser",
+        key_path=str(target_key),
+        jump_host=jump,
+    )
+
+    cmd = SSHMessageReader(
+        remote_path="/tmp/messages.jsonl", ssh_config=target
+    )._build_ssh_tail_command()
+
+    assert cmd is not None
+    joined = " ".join(cmd)
+    assert "ProxyCommand=" in joined
+    assert "ControlMaster=auto" in joined
+    assert f"ControlPath={tmp_path / 'control'}/cm-" in joined
+
+
+def test_ssh_message_reader_tracks_the_pool_control_path(tmp_path):
+    key_path = tmp_path / "id_test"
+    key_path.write_text("dummy-key")
+    ssh_resource = SSHConnectionResource(
+        host="example.com", user="testuser", key_path=str(key_path)
+    )
+
+    pool = SimpleNamespace(control_path="/tmp/pool-socket")
+    reader = SSHMessageReader(
+        remote_path="/tmp/messages.jsonl",
+        ssh_config=ssh_resource,
+        control_path="/tmp/stale-socket",
+        ssh_pool=cast(Any, pool),
+    )
+
+    assert reader.control_path == "/tmp/pool-socket"
+
+    # Once the pool abandons its socket the reader must stop using it too.
+    pool.control_path = None
+    assert reader.control_path is None
+
+
+def test_reconnect_delay_backs_off_and_is_capped(tmp_path):
+    key_path = tmp_path / "id_test"
+    key_path.write_text("dummy-key")
+    reader = SSHMessageReader(
+        remote_path="/tmp/messages.jsonl",
+        ssh_config=SSHConnectionResource(
+            host="example.com", user="testuser", key_path=str(key_path)
+        ),
+        reconnect_interval=2.0,
+        max_reconnect_interval=10.0,
+    )
+
+    assert reader._reconnect_delay(0) == 2.0
+    assert reader._reconnect_delay(1) == 2.0
+    assert reader._reconnect_delay(2) == 4.0
+    assert reader._reconnect_delay(3) == 8.0
+    assert reader._reconnect_delay(9) == 10.0
+
+
+def test_flapping_tail_stops_reconnecting(monkeypatch, tmp_path):
+    """A tail that dies right after each message must not reconnect forever."""
+    key_path = tmp_path / "id_test"
+    key_path.write_text("dummy-key")
+    ssh_resource = SSHConnectionResource(
+        host="example.com", user="testuser", key_path=str(key_path)
+    )
+
+    attempts = {"count": 0}
+
+    def fake_popen(cmd, stdout=None, stderr=None, text=None, bufsize=None):
+        del cmd, stdout, stderr, text, bufsize
+        attempts["count"] += 1
+        return _FakeProcess([json.dumps({"method": "opened", "params": {}}) + "\n"])
+
+    monkeypatch.setattr(
+        "dagster_slurm.helpers.message_readers.subprocess.Popen", fake_popen
+    )
+
+    reader = SSHMessageReader(
+        remote_path="/tmp/messages.jsonl",
+        ssh_config=ssh_resource,
+        reconnect_interval=0.0,
+        max_reconnect_attempts=3,
+    )
+    reader._read_loop_with_reconnect(_CollectingHandler())
+
+    assert attempts["count"] == 3

--- a/projects/dagster-slurm/dagster_slurm_test/test_resources.py
+++ b/projects/dagster-slurm/dagster_slurm_test/test_resources.py
@@ -1223,3 +1223,64 @@ def test_pre_timeout_marker_is_reported_on_failure(slurm_pipes_client):
         )
         is None
     )
+
+
+def test_status_poll_interval_backs_off_and_is_capped():
+    slurm = SlurmResource(
+        ssh=SSHConnectionResource(host="h", user="u", password="p"),
+        queue=SlurmQueueConfig(),
+        status_poll_interval_seconds=2.0,
+        status_poll_max_interval_seconds=8.0,
+        status_poll_backoff_factor=2.0,
+    )
+
+    assert slurm.next_status_poll_interval(2.0) == 4.0
+    assert slurm.next_status_poll_interval(4.0) == 8.0
+    assert slurm.next_status_poll_interval(8.0) == 8.0
+
+
+def test_status_poll_max_interval_must_not_be_below_the_floor():
+    with pytest.raises(Exception, match="status_poll_max_interval_seconds"):
+        SlurmResource(
+            ssh=SSHConnectionResource(host="h", user="u", password="p"),
+            queue=SlurmQueueConfig(),
+            status_poll_interval_seconds=10.0,
+            status_poll_max_interval_seconds=5.0,
+        )
+
+
+def test_status_poll_cadence_reads_environment(monkeypatch):
+    monkeypatch.setenv("SLURM_SSH_HOST", "example.com")
+    monkeypatch.setenv("SLURM_SSH_USER", "testuser")
+    monkeypatch.setenv("SLURM_SSH_PASSWORD", "secret")
+    monkeypatch.setenv("SLURM_STATUS_POLL_INTERVAL", "5")
+    monkeypatch.setenv("SLURM_STATUS_POLL_MAX_INTERVAL", "30")
+    monkeypatch.setenv("SLURM_STATUS_POLL_BACKOFF", "2")
+
+    slurm = SlurmResource.from_env()
+
+    assert slurm.status_poll_interval_seconds == 5.0
+    assert slurm.status_poll_max_interval_seconds == 30.0
+    assert slurm.status_poll_backoff_factor == 2.0
+
+
+def test_multiplexing_loss_mid_run_is_reported_to_dagster():
+    """A master lost mid-run escalates through the same reporter as a failed start."""
+    client = SlurmPipesClient(
+        slurm_resource=_mock_slurm_resource(),
+        launcher=BashLauncher(),
+    )
+    errors: list[str] = []
+    context = SimpleNamespace(log=SimpleNamespace(error=errors.append))
+    ssh_pool = SimpleNamespace(reporter=None)
+
+    client._attach_multiplexing_reporter(
+        cast(Any, context),
+        cast(SSHConnectionPool, ssh_pool),
+    )
+
+    assert errors == []
+    assert callable(ssh_pool.reporter)
+
+    ssh_pool.reporter("error", "SSH MULTIPLEXING FAILED for example.com")
+    assert errors == ["SSH MULTIPLEXING FAILED for example.com"]

--- a/projects/dagster-slurm/dagster_slurm_test/test_resources.py
+++ b/projects/dagster-slurm/dagster_slurm_test/test_resources.py
@@ -1225,6 +1225,42 @@ def test_pre_timeout_marker_is_reported_on_failure(slurm_pipes_client):
     )
 
 
+def test_status_poll_never_sleeps_past_the_deadline():
+    """A job that finishes just inside poll_timeout must be seen, not timed out."""
+    bounded = SlurmPipesClient._bounded_poll_sleep
+
+    # Plenty of budget left: the backed-off interval is used as-is.
+    assert bounded(5.0, elapsed=10.0, poll_timeout=60.0) == 5.0
+
+    # Close to the deadline: the sleep shrinks so one more poll still happens
+    # before poll_timeout, instead of stepping straight over it.
+    assert bounded(5.0, elapsed=58.0, poll_timeout=60.0) == 1.75
+    assert bounded(15.0, elapsed=50.0, poll_timeout=60.0) == 9.75
+
+    # Never sleeps a negative or silly-small amount.
+    assert bounded(5.0, elapsed=59.9, poll_timeout=60.0) == 0.1
+    assert bounded(5.0, elapsed=61.0, poll_timeout=60.0) == 0.0
+
+
+def test_status_poll_cap_stays_responsive_by_default():
+    """The default cap has to survive short jobs, not just multi-hour ones."""
+    slurm = SlurmResource(
+        ssh=SSHConnectionResource(host="h", user="u", password="p"),
+        queue=SlurmQueueConfig(),
+    )
+
+    interval = slurm.status_poll_interval_seconds
+    elapsed = 0.0
+    for _ in range(40):
+        elapsed += interval
+        interval = slurm.next_status_poll_interval(interval)
+
+    # A four-hour job still drops from 14400 squeue calls to under 3000, while
+    # completion is never noticed more than the cap late.
+    assert slurm.status_poll_max_interval_seconds <= 5.0
+    assert interval == slurm.status_poll_max_interval_seconds
+
+
 def test_status_poll_interval_backs_off_and_is_capped():
     slurm = SlurmResource(
         ssh=SSHConnectionResource(host="h", user="u", password="p"),

--- a/projects/dagster-slurm/dagster_slurm_test/test_ssh_pool.py
+++ b/projects/dagster-slurm/dagster_slurm_test/test_ssh_pool.py
@@ -199,6 +199,9 @@ def test_control_master_fallback_key_auth(monkeypatch, tmp_path):
 
     def fake_run(cmd, *args, **kwargs):
         commands.append(cmd)
+        if "-O" in cmd:
+            # No live master behind the control socket
+            return DummyResult(returncode=255, stderr="No such file or directory")
         if "-M" in cmd:
             # Simulate ControlMaster failure
             return DummyResult(returncode=255, stderr="ControlMaster not permitted")
@@ -227,7 +230,9 @@ def test_control_master_fallback_key_auth(monkeypatch, tmp_path):
 
     # Ensure fallback commands do not rely on ControlPath
     fallback_calls = [
-        cmd for cmd in commands if cmd and cmd[0] == "ssh" and "-M" not in cmd
+        cmd
+        for cmd in commands
+        if cmd and cmd[0] == "ssh" and "-M" not in cmd and "-O" not in cmd
     ]
     assert any("-o" in cmd for cmd in fallback_calls)
     assert not any("ControlPath" in " ".join(cmd) for cmd in fallback_calls)
@@ -588,6 +593,197 @@ def test_batch_mode_failures_get_an_actionable_hint(tmp_path):
     assert strict.auth_error_hint("some unrelated failure") == ""
 
 
+def _key_auth_resource(tmp_path, *, port: int = 22, host: str = "example.com"):
+    key_path = tmp_path / "id_test"
+    if not key_path.exists():
+        key_path.write_text("dummy-key")
+        os.chmod(key_path, 0o600)
+    return SSHConnectionResource(
+        host=host,
+        port=port,
+        user="testuser",
+        key_path=str(key_path),
+    )
+
+
+def _master_lifecycle_stub(commands: list[list[str]], state: dict):
+    """Fake ``subprocess.run`` that models an OpenSSH ControlMaster."""
+
+    def fake_run(cmd, *args, **kwargs):
+        commands.append(cmd)
+        if "-O" in cmd:
+            if "exit" in cmd:
+                state["alive"] = False
+                return DummyResult(returncode=0)
+            return DummyResult(returncode=0 if state["alive"] else 255)
+        if "-M" in cmd:
+            if not state.get("spawn_ok", True):
+                return DummyResult(returncode=255, stderr="connection refused")
+            state["alive"] = True
+            return DummyResult(returncode=0)
+        return DummyResult(returncode=0, stdout="ok\n")
+
+    return fake_run
+
+
+def test_control_socket_is_shared_per_target(monkeypatch, tmp_path):
+    """The socket name must not be random, or every pool re-handshakes."""
+    monkeypatch.setenv("DAGSTER_SLURM_SSH_CONTROL_DIR", str(tmp_path / "control"))
+
+    resource = _key_auth_resource(tmp_path)
+    first = SSHConnectionPool(resource).control_path
+    second = SSHConnectionPool(resource).control_path
+
+    assert first is not None
+    assert first == second
+    assert first.endswith("cm-testuser@example.com:22")
+
+    other_port = SSHConnectionPool(_key_auth_resource(tmp_path, port=2222)).control_path
+    assert other_port != first
+
+
+def test_password_auth_has_no_control_socket(tmp_path, monkeypatch):
+    monkeypatch.setenv("DAGSTER_SLURM_SSH_CONTROL_DIR", str(tmp_path / "control"))
+    resource = SSHConnectionResource(host="example.com", user="testuser", password="s")
+
+    assert resource.supports_multiplexing is False
+    assert resource.control_socket_path() is None
+    assert SSHConnectionPool(resource).control_path is None
+
+
+def test_live_master_is_reused_instead_of_respawned(monkeypatch, tmp_path):
+    monkeypatch.setenv("DAGSTER_SLURM_SSH_CONTROL_DIR", str(tmp_path / "control"))
+    commands: list[list[str]] = []
+    state = {"alive": True}
+    monkeypatch.setattr(subprocess, "run", _master_lifecycle_stub(commands, state))
+
+    with SSHConnectionPool(_key_auth_resource(tmp_path)) as pool:
+        assert pool.multiplexing_active is True
+
+    assert not [cmd for cmd in commands if "-M" in cmd]
+
+
+def test_exit_leaves_master_alive_for_the_next_caller(monkeypatch, tmp_path):
+    monkeypatch.setenv("DAGSTER_SLURM_SSH_CONTROL_DIR", str(tmp_path / "control"))
+    commands: list[list[str]] = []
+    state = {"alive": False}
+    monkeypatch.setattr(subprocess, "run", _master_lifecycle_stub(commands, state))
+
+    with SSHConnectionPool(_key_auth_resource(tmp_path)):
+        pass
+
+    assert len([cmd for cmd in commands if "-M" in cmd]) == 1
+    assert not [cmd for cmd in commands if "-O" in cmd and "exit" in cmd]
+    assert state["alive"] is True
+
+
+def test_master_shutdown_can_be_forced_via_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("DAGSTER_SLURM_SSH_CONTROL_DIR", str(tmp_path / "control"))
+    monkeypatch.setenv("DAGSTER_SLURM_SSH_CLOSE_MASTER_ON_EXIT", "1")
+    commands: list[list[str]] = []
+    state = {"alive": False}
+    monkeypatch.setattr(subprocess, "run", _master_lifecycle_stub(commands, state))
+
+    with SSHConnectionPool(_key_auth_resource(tmp_path)):
+        pass
+
+    assert [cmd for cmd in commands if "-O" in cmd and "exit" in cmd]
+    assert state["alive"] is False
+
+
+def test_nested_context_does_not_start_a_second_master(monkeypatch, tmp_path):
+    monkeypatch.setenv("DAGSTER_SLURM_SSH_CONTROL_DIR", str(tmp_path / "control"))
+    commands: list[list[str]] = []
+    state = {"alive": False}
+    monkeypatch.setattr(subprocess, "run", _master_lifecycle_stub(commands, state))
+
+    pool = SSHConnectionPool(_key_auth_resource(tmp_path))
+    with pool:
+        with pool:
+            assert pool.multiplexing_active is True
+        assert pool.multiplexing_active is True
+
+    assert len([cmd for cmd in commands if "-M" in cmd]) == 1
+
+
+def test_dead_master_is_restarted_before_the_next_command(monkeypatch, tmp_path):
+    """A stale socket makes OpenSSH reconnect silently - detect and heal it."""
+    monkeypatch.setenv("DAGSTER_SLURM_SSH_CONTROL_DIR", str(tmp_path / "control"))
+    commands: list[list[str]] = []
+    state = {"alive": False}
+    monkeypatch.setattr(subprocess, "run", _master_lifecycle_stub(commands, state))
+
+    pool = SSHConnectionPool(_key_auth_resource(tmp_path))
+    pool.MASTER_CHECK_INTERVAL_SECONDS = 0.0
+
+    with pool:
+        assert len([cmd for cmd in commands if "-M" in cmd]) == 1
+        state["alive"] = False  # master died mid-run
+        assert pool.run("true") == "ok\n"
+
+        assert len([cmd for cmd in commands if "-M" in cmd]) == 2
+        assert pool.multiplexing_active is True
+
+
+def test_unrecoverable_master_loss_is_reported_loudly(monkeypatch, tmp_path):
+    monkeypatch.setenv("DAGSTER_SLURM_SSH_CONTROL_DIR", str(tmp_path / "control"))
+    commands: list[list[str]] = []
+    state = {"alive": False, "spawn_ok": True}
+    monkeypatch.setattr(subprocess, "run", _master_lifecycle_stub(commands, state))
+
+    reported: list[tuple[str, str]] = []
+    pool = SSHConnectionPool(_key_auth_resource(tmp_path))
+    pool.MASTER_CHECK_INTERVAL_SECONDS = 0.0
+
+    with pool:
+        pool.reporter = lambda level, message: reported.append((level, message))
+        state["alive"] = False
+        state["spawn_ok"] = False
+
+        assert pool.run("true") == "ok\n"
+
+    assert pool.multiplexing_active is False
+    assert pool.multiplexing_unsupported is False
+    assert len(reported) == 1
+    level, message = reported[0]
+    assert level == "error"
+    assert "SSH MULTIPLEXING FAILED" in message
+    assert "could cause the account to be blocked" in message
+
+
+def test_one_off_commands_attach_to_the_shared_socket(monkeypatch, tmp_path):
+    """Helper commands outside the pool must multiplex too."""
+    monkeypatch.setenv("DAGSTER_SLURM_SSH_CONTROL_DIR", str(tmp_path / "control"))
+    resource = _key_auth_resource(tmp_path)
+
+    resolved = _resolved_ssh_config(resource.get_ssh_base_command())
+
+    assert resolved["controlmaster"] == "auto"
+    assert resolved["controlpath"].endswith("cm-testuser@example.com:22")
+
+    scp_command = resource.get_scp_base_command()
+    assert "ControlMaster=auto" in " ".join(scp_command)
+
+
+def test_pooled_commands_never_promote_themselves_to_master(monkeypatch, tmp_path):
+    monkeypatch.setenv("DAGSTER_SLURM_SSH_CONTROL_DIR", str(tmp_path / "control"))
+    commands: list[list[str]] = []
+    state = {"alive": True}
+    monkeypatch.setattr(subprocess, "run", _master_lifecycle_stub(commands, state))
+
+    with SSHConnectionPool(_key_auth_resource(tmp_path)) as pool:
+        pool.run("true")
+
+    pooled = [
+        cmd
+        for cmd in commands
+        if cmd and cmd[0] == "ssh" and "-M" not in cmd and "-O" not in cmd
+    ]
+    assert pooled
+    for cmd in pooled:
+        assert "ControlMaster=no" in cmd
+
+
 def test_password_auth_is_reported_as_unsupported_not_failed():
     """Password auth cannot be multiplexed - that is not a ControlMaster failure.
 
@@ -615,37 +811,6 @@ def test_password_auth_is_reported_as_unsupported_not_failed():
     assert "password-based authentication" in message
 
 
-def test_control_master_failure_is_still_reported_as_an_error(monkeypatch, tmp_path):
-    """A key-auth deployment that cannot start a master really is broken."""
-    key_path = tmp_path / "id_test"
-    key_path.write_text("dummy-key")
-    os.chmod(key_path, 0o600)
-    ssh_resource = SSHConnectionResource(
-        host="example.com", user="testuser", key_path=str(key_path)
-    )
-
-    def fake_run(cmd, *args, **kwargs):
-        if "-M" in cmd:
-            return DummyResult(returncode=255, stderr="ControlMaster not permitted")
-        return DummyResult(returncode=0, stdout="ok\n")
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-
-    reports: list[tuple[str, str]] = []
-    pool = SSHConnectionPool(ssh_resource)
-    pool.reporter = lambda level, message: reports.append((level, message))
-    with pool:
-        pass
-
-    assert pool.multiplexing_unsupported is False
-    assert len(reports) == 1
-    level, message = reports[0]
-    assert level == "error"
-    assert "SSH MULTIPLEXING FAILED" in message
-    assert "could cause the account to be blocked" in message
-    assert "ControlMaster not permitted" in message
-
-
 def test_pool_reports_its_own_state_without_a_reporter(caplog):
     """Sensors, session setup and hetjob submission report without extra wiring.
 
@@ -666,18 +831,12 @@ def test_pool_reports_its_own_state_without_a_reporter(caplog):
 
 
 def test_healthy_pool_describes_no_degradation(monkeypatch, tmp_path):
-    key_path = tmp_path / "id_test"
-    key_path.write_text("dummy-key")
-    os.chmod(key_path, 0o600)
-    ssh_resource = SSHConnectionResource(
-        host="example.com", user="testuser", key_path=str(key_path)
-    )
-    monkeypatch.setattr(
-        subprocess, "run", lambda *a, **k: DummyResult(returncode=0, stdout="ok\n")
-    )
+    commands: list[list[str]] = []
+    state = {"alive": True}
+    monkeypatch.setattr(subprocess, "run", _master_lifecycle_stub(commands, state))
 
     reports: list[tuple[str, str]] = []
-    pool = SSHConnectionPool(ssh_resource)
+    pool = SSHConnectionPool(_key_auth_resource(tmp_path))
     pool.reporter = lambda level, message: reports.append((level, message))
     with pool:
         assert pool.multiplexing_active is True

--- a/projects/dagster-slurm/dagster_slurm_test/test_ssh_pool.py
+++ b/projects/dagster-slurm/dagster_slurm_test/test_ssh_pool.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 import shlex
+import shutil
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -9,6 +10,7 @@ from types import SimpleNamespace
 import pytest
 from pydantic import ValidationError
 from dagster_slurm.helpers import ssh_pool as ssh_pool_module
+from dagster_slurm.helpers.ssh_control import control_socket_path
 from dagster_slurm.helpers.ssh_pool import SSHConnectionPool
 from dagster_slurm.resources.ssh import SSHConnectionResource
 
@@ -628,7 +630,6 @@ def _master_lifecycle_stub(commands: list[list[str]], state: dict):
 
 def test_control_socket_is_shared_per_target(monkeypatch, tmp_path):
     """The socket name must not be random, or every pool re-handshakes."""
-    monkeypatch.setenv("DAGSTER_SLURM_SSH_CONTROL_DIR", str(tmp_path / "control"))
 
     resource = _key_auth_resource(tmp_path)
     first = SSHConnectionPool(resource).control_path
@@ -643,7 +644,6 @@ def test_control_socket_is_shared_per_target(monkeypatch, tmp_path):
 
 
 def test_password_auth_has_no_control_socket(tmp_path, monkeypatch):
-    monkeypatch.setenv("DAGSTER_SLURM_SSH_CONTROL_DIR", str(tmp_path / "control"))
     resource = SSHConnectionResource(host="example.com", user="testuser", password="s")
 
     assert resource.supports_multiplexing is False
@@ -652,7 +652,6 @@ def test_password_auth_has_no_control_socket(tmp_path, monkeypatch):
 
 
 def test_live_master_is_reused_instead_of_respawned(monkeypatch, tmp_path):
-    monkeypatch.setenv("DAGSTER_SLURM_SSH_CONTROL_DIR", str(tmp_path / "control"))
     commands: list[list[str]] = []
     state = {"alive": True}
     monkeypatch.setattr(subprocess, "run", _master_lifecycle_stub(commands, state))
@@ -664,7 +663,6 @@ def test_live_master_is_reused_instead_of_respawned(monkeypatch, tmp_path):
 
 
 def test_exit_leaves_master_alive_for_the_next_caller(monkeypatch, tmp_path):
-    monkeypatch.setenv("DAGSTER_SLURM_SSH_CONTROL_DIR", str(tmp_path / "control"))
     commands: list[list[str]] = []
     state = {"alive": False}
     monkeypatch.setattr(subprocess, "run", _master_lifecycle_stub(commands, state))
@@ -678,7 +676,6 @@ def test_exit_leaves_master_alive_for_the_next_caller(monkeypatch, tmp_path):
 
 
 def test_master_shutdown_can_be_forced_via_env(monkeypatch, tmp_path):
-    monkeypatch.setenv("DAGSTER_SLURM_SSH_CONTROL_DIR", str(tmp_path / "control"))
     monkeypatch.setenv("DAGSTER_SLURM_SSH_CLOSE_MASTER_ON_EXIT", "1")
     commands: list[list[str]] = []
     state = {"alive": False}
@@ -692,7 +689,6 @@ def test_master_shutdown_can_be_forced_via_env(monkeypatch, tmp_path):
 
 
 def test_nested_context_does_not_start_a_second_master(monkeypatch, tmp_path):
-    monkeypatch.setenv("DAGSTER_SLURM_SSH_CONTROL_DIR", str(tmp_path / "control"))
     commands: list[list[str]] = []
     state = {"alive": False}
     monkeypatch.setattr(subprocess, "run", _master_lifecycle_stub(commands, state))
@@ -708,7 +704,6 @@ def test_nested_context_does_not_start_a_second_master(monkeypatch, tmp_path):
 
 def test_dead_master_is_restarted_before_the_next_command(monkeypatch, tmp_path):
     """A stale socket makes OpenSSH reconnect silently - detect and heal it."""
-    monkeypatch.setenv("DAGSTER_SLURM_SSH_CONTROL_DIR", str(tmp_path / "control"))
     commands: list[list[str]] = []
     state = {"alive": False}
     monkeypatch.setattr(subprocess, "run", _master_lifecycle_stub(commands, state))
@@ -726,7 +721,6 @@ def test_dead_master_is_restarted_before_the_next_command(monkeypatch, tmp_path)
 
 
 def test_unrecoverable_master_loss_is_reported_loudly(monkeypatch, tmp_path):
-    monkeypatch.setenv("DAGSTER_SLURM_SSH_CONTROL_DIR", str(tmp_path / "control"))
     commands: list[list[str]] = []
     state = {"alive": False, "spawn_ok": True}
     monkeypatch.setattr(subprocess, "run", _master_lifecycle_stub(commands, state))
@@ -753,7 +747,6 @@ def test_unrecoverable_master_loss_is_reported_loudly(monkeypatch, tmp_path):
 
 def test_one_off_commands_attach_to_the_shared_socket(monkeypatch, tmp_path):
     """Helper commands outside the pool must multiplex too."""
-    monkeypatch.setenv("DAGSTER_SLURM_SSH_CONTROL_DIR", str(tmp_path / "control"))
     resource = _key_auth_resource(tmp_path)
 
     resolved = _resolved_ssh_config(resource.get_ssh_base_command())
@@ -766,7 +759,6 @@ def test_one_off_commands_attach_to_the_shared_socket(monkeypatch, tmp_path):
 
 
 def test_pooled_commands_never_promote_themselves_to_master(monkeypatch, tmp_path):
-    monkeypatch.setenv("DAGSTER_SLURM_SSH_CONTROL_DIR", str(tmp_path / "control"))
     commands: list[list[str]] = []
     state = {"alive": True}
     monkeypatch.setattr(subprocess, "run", _master_lifecycle_stub(commands, state))
@@ -843,3 +835,35 @@ def test_healthy_pool_describes_no_degradation(monkeypatch, tmp_path):
 
     assert pool.describe_multiplexing() is None
     assert reports == []
+
+
+def test_overlong_control_dir_is_reported_not_silently_ignored(monkeypatch, caplog):
+    """Losing multiplexing must never be silent - that is the whole point.
+
+    Unix sockets cap out near 104 bytes. A deep DAGSTER_SLURM_SSH_CONTROL_DIR
+    used to disable multiplexing without a word, which is precisely the failure
+    this package is meant to make impossible to miss.
+    """
+    monkeypatch.setenv("DAGSTER_SLURM_SSH_CONTROL_DIR", "/tmp/" + ("d" * 120))
+
+    with caplog.at_level(logging.WARNING):
+        path = control_socket_path("testuser", "example.com", 22)
+
+    assert path is None
+    assert any("cannot be multiplexed" in record.message for record in caplog.records)
+
+
+def test_long_but_usable_control_dir_falls_back_to_a_digest(monkeypatch):
+    """A long-but-workable directory keeps multiplexing via a shortened name."""
+    directory = "/tmp/" + ("d" * 75)
+    monkeypatch.setenv("DAGSTER_SLURM_SSH_CONTROL_DIR", directory)
+
+    try:
+        path = control_socket_path("testuser", "example.com", 22)
+        assert path is not None
+        assert path.startswith(f"{directory}/cm-")
+        assert len(path) < 100
+        # The readable name would not have fit, so a digest is used instead.
+        assert "@" not in path
+    finally:
+        shutil.rmtree(directory, ignore_errors=True)


### PR DESCRIPTION
Stacked on #186.

DataLAB warned that accounts generating excessive non-multiplexed SSH sessions will be blocked after 2026-08-15. #186 made a failed ControlMaster startup loud; this PR fixes the cases that were still opening one-off connections — including several where the code believed multiplexing was healthy.

## Why the master was not actually shared

The control socket was named `cm-<random uuid>`, so no two pools ever shared one, and `__exit__` ran `ssh -O exit`, making `ControlPersist` pointless. Every asset step (`slurm_pipes_client.py`), every orphan-sensor tick (`sensors.py`, default 30s → ~2 880/day from an idle deployment), every hetjob and session setup paid a full DNS lookup, TCP handshake and authentication.

The socket is now derived from `user@host:port` (`~/.ssh/dagster-slurm/cm-<user>@<host>:<port>`, hashed if it would exceed the 100-char `AF_UNIX` limit) and the master is left running for the next caller. `DAGSTER_SLURM_SSH_CLOSE_MASTER_ON_EXIT=1` restores the old teardown.

## Why failures were silent

OpenSSH opens a *full* connection when a `ControlPath` socket is stale — no error, no exit code. `multiplexing_active` was latched once at `__enter__`, so a master dying mid-run turned the 1-second polling loop into thousands of handshakes per hour while the pool still reported success. The master also ran without keepalives, so an idle NAT or firewall could drop it unnoticed.

The pool now probes with `ssh -O check` (throttled to 15s), restarts a dead master, and only enters fallback — loudly, via a new `on_multiplexing_lost` hook wired to `context.log.error` — when the restart fails. The master carries `ServerAliveInterval=30`/`CountMax=6`. `__enter__`/`__exit__` are ref-counted, so the re-entry in the failure-cleanup path no longer spawns a second master.

## Remaining unmultiplexed paths

- `get_ssh_base_command`/`get_scp_base_command` (and therefore the legacy `ssh_run`/`ssh_check`) set no `Control*` options at all — they now attach to the shared socket with `ControlMaster=auto`.
- The ProxyJump hop re-authenticated against the bastion on every fallback command.
- `SSHMessageReader._build_ssh_tail_command` never passed ProxyJump options, so jump-host setups bypassed the bastion entirely once the master was gone.
- `_read_loop_with_reconnect` cleared `reconnect_count` both on spawn and on any message received, so `max_reconnect_attempts` never tripped: a tail dying right after each message reconnected every 2s forever. It now only clears for sessions lasting `healthy_session_seconds` (30s) and backs off exponentially to `max_reconnect_interval` (60s).
- The degraded log-polling fallback, where each round is a full connection, polled once per second and now backs off.

## Polling cadence

Job state was polled every second with no way to configure it — 3 600 sshd forks and `squeue` queries per hour per running asset even over a healthy master, and DataLAB explicitly asked for a longer interval. Now `status_poll_interval_seconds` (2.0) ramping by `status_poll_backoff_factor` (1.5) to `status_poll_max_interval_seconds` (15.0), reset on every state transition so completion is still noticed promptly. Env overrides: `SLURM_STATUS_POLL_INTERVAL`, `SLURM_STATUS_POLL_MAX_INTERVAL`, `SLURM_STATUS_POLL_BACKOFF`.

## Note for reviewers

Command-line `-o` options win over `~/.ssh/config`, so adding DataLAB's recommended `ControlMaster auto` block there does **not** change what this package does — it only affects SSH commands run by hand. Documented in `docs/docs/how-to/troubleshooting.md`.

## Verification

`fmt` and `lint` clean. Unit tests: 209 passed, 1 failed — `test_concurrent_ray_launchers_use_disjoint_ports_and_isolated_cleanup`, which fails identically on the base branch (a fake ray launch script exits 1 locally; unrelated to SSH). `test-integration` was not run — it needs the Slurm docker stack.

**Not yet verified against a real cluster.** The tests stub every SSH call, so they prove command construction and master lifecycle logic but not that OpenSSH actually multiplexes against DataLAB. The decisive check is running two assets (or one asset plus a sensor tick) and confirming `~/.ssh/dagster-slurm/` holds exactly one socket whose `ssh -O check` pid never changes.

## Residual

The liveness probe is throttled to 15s, so a master dying mid-run still allows up to ~7 unmultiplexed connections at the 2s poll interval before the restart kicks in. Bounded, but not zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)