### PR TITLE
feat: add extensible Slurm GPU metrics

### DIFF
--- a/docs/docs/how-to/execution-modes.md
+++ b/docs/docs/how-to/execution-modes.md
@@ -49,6 +49,7 @@ compute = ComputeResource(
 - Each run file-packages the asset environment using `pixi-pack` (unless `pre_deployed_env_path` is set).
 - Jobs terminate as soon as the asset finishes—ideal for isolated workloads.
 - Override `launcher=` on individual assets to run Ray or Spark (WIP) workloads inside the allocation.
+- Completed jobs include CPU, memory, and GPU TRES materialization metadata. See [Collect Slurm job metrics](./job-metrics.md).
 
 ## Slurm mode with run-scoped Ray allocation
 

--- a/docs/docs/how-to/job-metrics.md
+++ b/docs/docs/how-to/job-metrics.md
@@ -1,0 +1,99 @@
+---
+sidebar_position: 3
+title: Slurm job metrics
+---
+
+`dagster-slurm` attaches `sacct` metrics to each Dagster materialization:
+
+- standalone mode: metrics for the completed job;
+- shared allocation: metrics for the completed `srun` step. The allocation remains active.
+
+## Default metadata
+
+| Key                              | Slurm source                         |
+| -------------------------------- | ------------------------------------ |
+| `slurm_job_id`                   | Job or allocation ID                 |
+| `slurm_step_id`                  | Step ID, for shared allocations      |
+| `elapsed_seconds`                | `Elapsed`                            |
+| `node_hours`                     | `Elapsed × AllocNodes`               |
+| `cpu_efficiency_pct`             | `TotalCPU / (Elapsed × AllocCPUS)`   |
+| `max_memory_mb`                  | `MaxRSS`                             |
+| `slurm_requested_gpus`           | `ReqTRES`                            |
+| `slurm_allocated_gpus`           | `AllocTRES`                          |
+| `slurm_gpu_utilization_avg_pct`  | `TRESUsageInAve: gres/gpuutil`       |
+| `slurm_gpu_utilization_max_pct`  | `TRESUsageInMax: gres/gpuutil`       |
+| `slurm_gpu_memory_max_mb`        | `TRESUsageInMax: gres/gpumem`        |
+| `slurm_gpu_utilization_max_node` | `TRESUsageInMaxNode: gres/gpuutil`   |
+| `slurm_tres_accounting`          | Raw job and step TRES rows as JSON   |
+| `slurm_accounting_available`     | Whether `sacct` returned usable data |
+| `slurm_gpu_accounting_available` | Whether GPU usage TRES were present  |
+
+An unavailable metric is omitted. A reported zero remains `0`.
+
+GPU utilization requires `AccountingStorageTRES=gres/gpu` and GPU GRES accounting,
+usually `AutoDetect=nvml` for NVIDIA or `AutoDetect=rsmi` for AMD. MIG utilization is
+not available through NVML. These values are post-run summaries, not an `nvtop`-style
+time series.
+
+All built-in metrics are enabled by default. Select a subset per run:
+
+```python
+from dagster_slurm import SlurmMetric
+
+compute.run(
+    context=context,
+    payload_path="train.py",
+    slurm_metrics={
+        SlurmMetric.GPU_UTILIZATION_AVG,
+        SlurmMetric.GPU_UTILIZATION_MAX,
+        SlurmMetric.GPU_MEMORY_MAX,
+    },
+)
+```
+
+Pass `slurm_metrics=[]` to disable optional built-in metrics. Job and step IDs plus
+`slurm_accounting_available` are always attached. Custom metrics are unaffected.
+
+## Custom metrics
+
+Pass a function, lambda, or closure to `ComputeResource.run()`:
+
+```python
+from dagster_slurm import ComputeResource, SlurmMetricsContext
+
+
+def collect_energy(metrics: SlurmMetricsContext) -> dict[str, float]:
+    target = metrics.step_id or str(metrics.job_id)
+    value = metrics.ssh_pool.run(
+        f"sacct -j {target} -n -o ConsumedEnergyRaw"
+    ).strip()
+    return {"site/energy_joules": float(value)}
+
+
+def training(context, compute: ComputeResource):
+    return compute.run(
+        context=context,
+        payload_path="train.py",
+        metrics_collector=collect_energy,
+    ).get_results()
+```
+
+`SlurmMetricsContext` provides `job_id`, `step_id`, `ssh_pool`, `slurm_resource`,
+`session_resource`, and `default_metrics`.
+
+Collector rules:
+
+- keys must be strings;
+- values must be valid Dagster metadata values;
+- built-in keys cannot be replaced;
+- errors are logged and do not fail the asset.
+
+Do not return secrets: metadata is stored in Dagster run history.
+
+## Persistent Ray allocations
+
+For ordinary asset-owned `srun` steps, shared-allocation metrics are per asset.
+
+With a persistent Ray cluster, Slurm accounts GPU work to the long-lived Ray worker
+steps, not to each asset driver. Use a custom collector backed by Ray metrics or NVML
+when per-asset GPU attribution is required.

--- a/projects/dagster-slurm/dagster_slurm/__init__.py
+++ b/projects/dagster-slurm/dagster_slurm/__init__.py
@@ -13,6 +13,7 @@ Run Dagster assets on Slurm clusters with support for:
 from .config.runtime import SlurmRunConfig
 
 # Core resources
+from .helpers.metrics import SlurmMetric, SlurmMetricsCallback, SlurmMetricsContext
 from .launchers.ray import RayLauncher, RayPortConfig
 
 # Launchers
@@ -56,6 +57,9 @@ __all__ = [
     # Advanced: Direct client access
     "LocalPipesClient",
     "SlurmPipesClient",
+    "SlurmMetric",
+    "SlurmMetricsCallback",
+    "SlurmMetricsContext",
     # Sensors / reconciliation helpers
     "build_slurm_orphan_reconcile_sensor",
     "reconcile_orphaned_slurm_runs",

--- a/projects/dagster-slurm/dagster_slurm/helpers/__init__.py
+++ b/projects/dagster-slurm/dagster_slurm/helpers/__init__.py
@@ -2,7 +2,12 @@
 
 from .env_packaging import pack_environment_with_pixi
 from .message_readers import LocalMessageReader, SSHMessageReader
-from .metrics import SlurmJobMetrics, SlurmMetricsCollector
+from .metrics import (
+    SlurmJobMetrics,
+    SlurmMetricsCallback,
+    SlurmMetricsCollector,
+    SlurmMetricsContext,
+)
 from .ssh_helpers import TERMINAL_STATES, normalize_slurm_state, ssh_check, ssh_run
 from .ssh_pool import SSHConnectionPool
 
@@ -16,5 +21,7 @@ __all__ = [
     "SSHMessageReader",
     "pack_environment_with_pixi",
     "SlurmMetricsCollector",
+    "SlurmMetricsCallback",
+    "SlurmMetricsContext",
     "SlurmJobMetrics",
 ]

--- a/projects/dagster-slurm/dagster_slurm/helpers/metrics.py
+++ b/projects/dagster-slurm/dagster_slurm/helpers/metrics.py
@@ -1,206 +1,506 @@
-"""Slurm job metrics collection."""
+"""Slurm job metrics collection and extension hooks."""
+
+from __future__ import annotations
 
 import re
-from typing import Optional
-from dataclasses import dataclass
-from dagster import get_dagster_logger
+from collections.abc import Callable, Collection, Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+from dagster import MetadataValue, get_dagster_logger
+
+if TYPE_CHECKING:
+    from dagster_slurm.helpers.ssh_pool import SSHConnectionPool
+    from dagster_slurm.resources.session import SlurmSessionResource
+    from dagster_slurm.resources.slurm import SlurmResource
 
 
-@dataclass
+DEFAULT_SLURM_METADATA_KEYS = frozenset(
+    {
+        "slurm_job_id",
+        "slurm_step_id",
+        "slurm_accounting_available",
+        "node_hours",
+        "cpu_efficiency_pct",
+        "max_memory_mb",
+        "elapsed_seconds",
+        "slurm_state",
+        "slurm_exit_code",
+        "slurm_gpu_accounting_available",
+        "slurm_requested_gpus",
+        "slurm_allocated_gpus",
+        "slurm_gpu_utilization_avg_pct",
+        "slurm_gpu_utilization_max_pct",
+        "slurm_gpu_memory_max_mb",
+        "slurm_gpu_utilization_max_node",
+        "slurm_tres_accounting",
+    }
+)
+
+
+class SlurmMetric(str, Enum):
+    """Optional built-in Slurm metadata fields."""
+
+    ELAPSED_SECONDS = "elapsed_seconds"
+    NODE_HOURS = "node_hours"
+    CPU_EFFICIENCY = "cpu_efficiency_pct"
+    MAX_MEMORY = "max_memory_mb"
+    STATE = "slurm_state"
+    EXIT_CODE = "slurm_exit_code"
+    GPU_ACCOUNTING_AVAILABLE = "slurm_gpu_accounting_available"
+    REQUESTED_GPUS = "slurm_requested_gpus"
+    ALLOCATED_GPUS = "slurm_allocated_gpus"
+    GPU_UTILIZATION_AVG = "slurm_gpu_utilization_avg_pct"
+    GPU_UTILIZATION_MAX = "slurm_gpu_utilization_max_pct"
+    GPU_MEMORY_MAX = "slurm_gpu_memory_max_mb"
+    GPU_UTILIZATION_MAX_NODE = "slurm_gpu_utilization_max_node"
+    TRES_ACCOUNTING = "slurm_tres_accounting"
+
+
+ALL_SLURM_METRICS = frozenset(SlurmMetric)
+SlurmMetricSelection = Collection[SlurmMetric | str]
+
+
+def normalize_slurm_metrics(
+    metrics: SlurmMetricSelection | None,
+) -> frozenset[SlurmMetric]:
+    """Validate a built-in metric selection; ``None`` enables every metric."""
+    if metrics is None:
+        return ALL_SLURM_METRICS
+    if isinstance(metrics, str):
+        raise ValueError("slurm_metrics must be a collection, not a single string")
+
+    try:
+        return frozenset(SlurmMetric(metric) for metric in metrics)
+    except (TypeError, ValueError) as error:
+        valid = ", ".join(metric.value for metric in SlurmMetric)
+        raise ValueError(f"Unknown Slurm metric. Valid values: {valid}") from error
+
+
+@dataclass(frozen=True)
 class SlurmJobMetrics:
-    """Metrics from sacct."""
+    """Metrics collected from Slurm accounting."""
 
     job_id: int
     elapsed_seconds: float
     cpu_time_seconds: float
     max_rss_mb: float
     node_hours: float
-    cpu_efficiency: float  # 0.0 to 1.0
+    cpu_efficiency: float
     state: str
     exit_code: int
+    accounting_available: bool = True
+    requested_gpus: int | None = None
+    allocated_gpus: int | None = None
+    gpu_utilization_avg_pct: float | None = None
+    gpu_utilization_max_pct: float | None = None
+    gpu_memory_max_mb: float | None = None
+    gpu_utilization_max_node: str | None = None
+    accounting_rows: tuple[dict[str, str], ...] = field(default_factory=tuple)
+    step_id: str | None = None
+
+    @property
+    def gpu_accounting_available(self) -> bool:
+        """Whether Slurm reported any GPU utilization or memory values."""
+        return any(
+            value is not None
+            for value in (
+                self.gpu_utilization_avg_pct,
+                self.gpu_utilization_max_pct,
+                self.gpu_memory_max_mb,
+            )
+        )
+
+    def to_metadata(
+        self,
+        slurm_metrics: SlurmMetricSelection | None = None,
+    ) -> dict[str, Any]:
+        """Return Dagster metadata for this accounting result."""
+        enabled = normalize_slurm_metrics(slurm_metrics)
+        metadata: dict[str, Any] = {
+            "slurm_job_id": self.job_id,
+            "slurm_accounting_available": self.accounting_available,
+        }
+        if self.step_id is not None:
+            metadata["slurm_step_id"] = self.step_id
+        if not self.accounting_available:
+            return metadata
+
+        values: dict[SlurmMetric, Any] = {
+            SlurmMetric.NODE_HOURS: round(self.node_hours, 4),
+            SlurmMetric.CPU_EFFICIENCY: round(self.cpu_efficiency * 100, 2),
+            SlurmMetric.MAX_MEMORY: round(self.max_rss_mb, 2),
+            SlurmMetric.ELAPSED_SECONDS: round(self.elapsed_seconds, 2),
+            SlurmMetric.STATE: self.state,
+            SlurmMetric.EXIT_CODE: self.exit_code,
+            SlurmMetric.GPU_ACCOUNTING_AVAILABLE: self.gpu_accounting_available,
+            SlurmMetric.REQUESTED_GPUS: self.requested_gpus,
+            SlurmMetric.ALLOCATED_GPUS: self.allocated_gpus,
+            SlurmMetric.GPU_UTILIZATION_AVG: self.gpu_utilization_avg_pct,
+            SlurmMetric.GPU_UTILIZATION_MAX: self.gpu_utilization_max_pct,
+            SlurmMetric.GPU_MEMORY_MAX: self.gpu_memory_max_mb,
+            SlurmMetric.GPU_UTILIZATION_MAX_NODE: self.gpu_utilization_max_node,
+        }
+        metadata.update(
+            {
+                metric.value: round(value, 2) if isinstance(value, float) else value
+                for metric, value in values.items()
+                if metric in enabled and value is not None
+            }
+        )
+        if SlurmMetric.TRES_ACCOUNTING in enabled and self.accounting_rows:
+            metadata["slurm_tres_accounting"] = MetadataValue.json(
+                list(self.accounting_rows)
+            )
+        return metadata
+
+
+@dataclass(frozen=True)
+class SlurmMetricsContext:
+    """Context passed to a custom post-run metrics collector."""
+
+    job_id: int
+    ssh_pool: SSHConnectionPool
+    slurm_resource: SlurmResource
+    session_resource: SlurmSessionResource | None
+    default_metrics: SlurmJobMetrics
+    step_id: str | None = None
+
+
+SlurmMetricsCallback = Callable[[SlurmMetricsContext], Mapping[str, Any]]
 
 
 class SlurmMetricsCollector:
-    """Collects detailed metrics from Slurm jobs."""
+    """Collect CPU, memory, and GPU TRES metrics from completed Slurm jobs."""
 
-    def __init__(self):
+    BASE_SACCT_FIELDS = (
+        "JobID",
+        "Elapsed",
+        "TotalCPU",
+        "MaxRSS",
+        "AllocNodes",
+        "AllocCPUS",
+        "State",
+        "ExitCode",
+    )
+    GPU_SACCT_FIELDS = (
+        "NodeList",
+        "ReqTRES",
+        "AllocTRES",
+        "TRESUsageInAve",
+        "TRESUsageInMax",
+        "TRESUsageInMaxNode",
+        "TRESUsageInMaxTask",
+        "TRESUsageInTot",
+    )
+    SACCT_FIELDS = BASE_SACCT_FIELDS + GPU_SACCT_FIELDS
+    BASE_SACCT_FORMAT = ",".join(BASE_SACCT_FIELDS)
+    SACCT_FORMAT = ",".join(SACCT_FIELDS)
+
+    def __init__(self) -> None:
         self.logger = get_dagster_logger()
-
-    #: sacct fields this collector parses, in order.
-    SACCT_FORMAT = "JobID,Elapsed,TotalCPU,MaxRSS,AllocNodes,AllocCPUS,State,ExitCode"
 
     def collect_job_metrics(
         self,
         job_id: int,
-        ssh_pool,
-        sacct_output: Optional[str] = None,
+        ssh_pool: SSHConnectionPool,
+        sacct_output: str | None = None,
+        step_id: str | None = None,
     ) -> SlurmJobMetrics:
-        """Query sacct for detailed job statistics.
-
-        Args:
-            job_id: Slurm job ID
-            ssh_pool: SSH connection pool
-            sacct_output: Pre-fetched sacct output in ``SACCT_FORMAT``, so a
-                caller that already queried accounting does not pay a second
-                round trip to the login node.
-
-        Returns:
-            SlurmJobMetrics with detailed stats
-        """
-        # This provides raw data for the main script step, including memory (MaxRSS).
-        cmd = f"sacct -j {job_id}.batch -n -P --format={self.SACCT_FORMAT}"
-
+        """Query ``sacct`` and parse job-, step-, and node-aware metrics."""
         try:
-            if sacct_output is None:
-                output = ssh_pool.run(cmd).strip()
-            else:
-                # Keep only the batch step row from the shared query.
-                output = "\n".join(
-                    line
-                    for line in sacct_output.strip().splitlines()
-                    if line.split("|", maxsplit=1)[0].strip() == f"{job_id}.batch"
-                )
+            if step_id is not None and not re.fullmatch(
+                rf"{job_id}\.[A-Za-z0-9_+-]+", step_id
+            ):
+                raise ValueError(f"Invalid Slurm step ID: {step_id!r}")
+            accounting_target = step_id or str(job_id)
+            output = sacct_output
+            if output is None:
+                output = ssh_pool.run(
+                    f"sacct -j {accounting_target} -n -P "
+                    f"--format={self.SACCT_FORMAT} "
+                    "2>/dev/null || true"
+                ).strip()
+                if not output:
+                    output = ssh_pool.run(
+                        f"sacct -j {accounting_target} -n -P "
+                        f"--format={self.BASE_SACCT_FORMAT} 2>/dev/null || true"
+                    ).strip()
 
-            # Handle cases where the batch step might not exist or returns no output.
-            if not output:
-                self.logger.warning(
-                    f"No sacct output found for job step {job_id}.batch."
-                )
-                return self._empty_metrics(job_id)
+            rows = self._parse_accounting_rows(output)
+            if not rows:
+                self.logger.warning("No sacct metrics found for job %s.", job_id)
+                return self._empty_metrics(job_id, step_id=step_id)
 
-            # Take the first line of output in case of unexpected extra lines.
-            line = output.splitlines()[0]
-            fields = line.split("|")
+            primary = self._select_primary_row(job_id, rows, step_id=step_id)
+            elapsed = self._parse_time(primary["Elapsed"])
+            cpu_time = self._parse_time(primary["TotalCPU"])
+            max_rss = self._parse_memory(primary["MaxRSS"])
+            nodes = self._parse_int(primary["AllocNodes"])
+            cpus = self._parse_int(primary["AllocCPUS"])
+            cpu_efficiency = (
+                cpu_time / (elapsed * cpus) if elapsed > 0 and cpus > 0 else 0.0
+            )
 
-            if len(fields) < 8:
-                self.logger.warning(f"Incomplete metrics for job {job_id}: {line}")
-                return self._empty_metrics(job_id)
+            return SlurmJobMetrics(
+                job_id=job_id,
+                elapsed_seconds=elapsed,
+                cpu_time_seconds=cpu_time,
+                max_rss_mb=max_rss,
+                node_hours=(elapsed / 3600) * nodes,
+                cpu_efficiency=min(cpu_efficiency, 1.0),
+                state=primary["State"],
+                exit_code=self._parse_exit_code(primary["ExitCode"]),
+                requested_gpus=self._gpu_count(rows, "ReqTRES"),
+                allocated_gpus=self._gpu_count(rows, "AllocTRES"),
+                gpu_utilization_avg_pct=self._primary_gpu_value(
+                    job_id,
+                    rows,
+                    "TRESUsageInAve",
+                    "gres/gpuutil",
+                    step_id=step_id,
+                ),
+                gpu_utilization_max_pct=self._max_gpu_value(
+                    rows, "TRESUsageInMax", "gres/gpuutil", memory=False
+                ),
+                gpu_memory_max_mb=self._max_gpu_value(
+                    rows, "TRESUsageInMax", "gres/gpumem", memory=True
+                ),
+                gpu_utilization_max_node=self._gpu_max_origin(
+                    rows,
+                    value_field_name="TRESUsageInMax",
+                    origin_field_name="TRESUsageInMaxNode",
+                    tres_name="gres/gpuutil",
+                ),
+                accounting_rows=tuple(self._audit_row(row) for row in rows),
+                step_id=step_id,
+            )
+        except Exception as error:
+            self.logger.warning(
+                "Failed to collect metrics for job %s: %s", job_id, error
+            )
+            return self._empty_metrics(job_id, step_id=step_id)
 
-            try:
-                # The JobID field in the output is now the step ID (e.g., "16.batch")
-                # We use the original job_id for consistency in our dataclass.
-                elapsed = self._parse_time(fields[1])
-                cpu_time = self._parse_time(fields[2])
-                max_rss = self._parse_memory(fields[3])
-                nodes = int(fields[4])
-                cpus = int(fields[5])
-                state = fields[6]
-                exit_code = self._parse_exit_code(fields[7])
+    def _parse_accounting_rows(self, output: str | None) -> list[dict[str, str]]:
+        """Parse parsable ``sacct`` output, accepting the base format as fallback."""
+        if not output:
+            return []
 
-                node_hours = (elapsed / 3600) * nodes
-                cpu_efficiency = (
-                    (cpu_time / (elapsed * cpus)) if elapsed > 0 and cpus > 0 else 0.0
-                )
+        rows: list[dict[str, str]] = []
+        for line in output.splitlines():
+            values = [value.strip() for value in line.split("|")]
+            if len(values) < len(self.BASE_SACCT_FIELDS) or not values[0]:
+                continue
+            padded_values = values + [""] * (len(self.SACCT_FIELDS) - len(values))
+            rows.append(dict(zip(self.SACCT_FIELDS, padded_values)))
+        return rows
 
-                return SlurmJobMetrics(
-                    job_id=job_id,
-                    elapsed_seconds=elapsed,
-                    cpu_time_seconds=cpu_time,
-                    max_rss_mb=max_rss,
-                    node_hours=node_hours,
-                    cpu_efficiency=min(cpu_efficiency, 1.0),  # Cap at 100%
-                    state=state,
-                    exit_code=exit_code,
-                )
+    @staticmethod
+    def _select_primary_row(
+        job_id: int,
+        rows: list[dict[str, str]],
+        *,
+        step_id: str | None = None,
+    ) -> dict[str, str]:
+        expected_ids = (
+            (step_id, f"{job_id}.batch", str(job_id))
+            if step_id is not None
+            else (f"{job_id}.batch", str(job_id))
+        )
+        for expected_id in expected_ids:
+            for row in rows:
+                if row["JobID"] == expected_id:
+                    return row
+        return rows[0]
 
-            except Exception as e:
-                self.logger.error(
-                    f"Error parsing metrics for job {job_id} on data '{line}': {e}"
-                )
-                return self._empty_metrics(job_id)
+    @staticmethod
+    def _parse_tres(value: str) -> dict[str, str]:
+        parsed: dict[str, str] = {}
+        for item in value.split(","):
+            key, separator, raw_value = item.strip().partition("=")
+            if separator and key:
+                parsed[key] = raw_value
+        return parsed
 
-        except Exception as e:
-            self.logger.warning(f"Failed to collect metrics for job {job_id}: {e}")
-            return self._empty_metrics(job_id)
+    def _gpu_count(self, rows: list[dict[str, str]], field_name: str) -> int | None:
+        counts: list[int] = []
+        for row in rows:
+            tres = self._parse_tres(row[field_name])
+            if "gres/gpu" in tres:
+                counts.append(self._parse_int(tres["gres/gpu"]))
+                continue
+            typed_counts = [
+                self._parse_int(value)
+                for key, value in tres.items()
+                if key.startswith("gres/gpu:")
+            ]
+            if typed_counts:
+                counts.append(sum(typed_counts))
+        return max(counts) if counts else None
+
+    def _primary_gpu_value(
+        self,
+        job_id: int,
+        rows: list[dict[str, str]],
+        field_name: str,
+        tres_name: str,
+        *,
+        step_id: str | None = None,
+    ) -> float | None:
+        primary = self._select_primary_row(job_id, rows, step_id=step_id)
+        value = self._find_tres_value(primary[field_name], tres_name)
+        if value is not None:
+            return self._parse_number(value)
+        return self._max_gpu_value(rows, field_name, tres_name, memory=False)
+
+    def _max_gpu_value(
+        self,
+        rows: list[dict[str, str]],
+        field_name: str,
+        tres_name: str,
+        *,
+        memory: bool,
+    ) -> float | None:
+        values: list[float] = []
+        for row in rows:
+            raw_value = self._find_tres_value(row[field_name], tres_name)
+            if raw_value is None:
+                continue
+            values.append(
+                self._parse_memory(raw_value)
+                if memory
+                else self._parse_number(raw_value)
+            )
+        return max(values) if values else None
+
+    def _gpu_max_origin(
+        self,
+        rows: list[dict[str, str]],
+        *,
+        value_field_name: str,
+        origin_field_name: str,
+        tres_name: str,
+    ) -> str | None:
+        maximum: float | None = None
+        maximum_origin: str | None = None
+        for row in rows:
+            raw_value = self._find_tres_value(row[value_field_name], tres_name)
+            origin = self._find_tres_value(row[origin_field_name], tres_name)
+            if raw_value is None or origin is None:
+                continue
+            value = self._parse_number(raw_value)
+            if maximum is None or value > maximum:
+                maximum = value
+                maximum_origin = origin
+        return maximum_origin
+
+    def _find_tres_value(self, raw_tres: str, tres_name: str) -> str | None:
+        tres = self._parse_tres(raw_tres)
+        if tres_name in tres:
+            return tres[tres_name]
+        typed_values = [
+            value for key, value in tres.items() if key.startswith(f"{tres_name}:")
+        ]
+        return typed_values[0] if typed_values else None
+
+    @staticmethod
+    def _audit_row(row: dict[str, str]) -> dict[str, str]:
+        """Keep raw scheduler values needed to audit per-step GPU summaries."""
+        fields = (
+            "JobID",
+            "NodeList",
+            "ReqTRES",
+            "AllocTRES",
+            "TRESUsageInAve",
+            "TRESUsageInMax",
+            "TRESUsageInMaxNode",
+            "TRESUsageInMaxTask",
+            "TRESUsageInTot",
+        )
+        return {field_name: row[field_name] for field_name in fields}
 
     def _parse_time(self, time_str: str) -> float:
         """Parse Slurm time format to seconds, including milliseconds."""
-        # Handle sub-second precision and improve robustness.
         if not time_str or time_str == "00:00:00":
             return 0.0
 
         days_seconds = 0.0
         if "-" in time_str:
             try:
-                days_str, time_str = time_str.split("-")
+                days_str, time_str = time_str.split("-", maxsplit=1)
                 days_seconds = float(days_str) * 86400
             except ValueError:
-                self.logger.warning(
-                    f"Could not parse days from time string: '{time_str}'"
-                )
+                self.logger.warning("Could not parse Slurm time: %r", time_str)
                 return 0.0
 
         parts = time_str.split(":")
-
         try:
-            if len(parts) == 3:  # HH:MM:SS.ms
-                h, m = float(parts[0]), float(parts[1])
-                s_part = parts[2]
-            elif len(parts) == 2:  # MM:SS.ms
-                h = 0.0
-                m, s_part = float(parts[0]), parts[1]
-            elif len(parts) == 1:  # SS.ms
-                h, m = 0.0, 0.0
-                s_part = parts[0]
+            if len(parts) == 3:
+                hours, minutes, seconds = map(float, parts)
+            elif len(parts) == 2:
+                hours = 0.0
+                minutes, seconds = map(float, parts)
+            elif len(parts) == 1:
+                hours = minutes = 0.0
+                seconds = float(parts[0])
             else:
                 return 0.0
-
-            # Handle fractional seconds
-            if "." in s_part:
-                sec, ms = s_part.split(".")
-                total_seconds = (
-                    days_seconds
-                    + h * 3600
-                    + m * 60
-                    + float(sec)
-                    + float(ms.ljust(3, "0")) / 1000.0
-                )
-            else:
-                total_seconds = days_seconds + h * 3600 + m * 60 + float(s_part)
-
-            return total_seconds
-        except (ValueError, IndexError):
-            self.logger.warning(f"Could not parse time parts from: '{time_str}'")
+            return days_seconds + hours * 3600 + minutes * 60 + seconds
+        except ValueError:
+            self.logger.warning("Could not parse Slurm time: %r", time_str)
             return 0.0
 
     def _parse_memory(self, mem_str: str) -> float:
-        """Parse Slurm memory format to MB, correctly handling suffixes and defaults."""
+        """Parse a Slurm memory value into MiB."""
         if not mem_str:
             return 0.0
-
-        mem_str = mem_str.strip().upper()
-
-        # Default to Kilobytes if no suffix is present, which is common for MaxRSS
-        match = re.match(r"([\d.]+)([KMGT])?$", mem_str)
+        match = re.fullmatch(r"([\d.]+)([KMGTPE]?)B?", mem_str.strip().upper())
         if not match:
-            self.logger.warning(f"Could not parse memory string: '{mem_str}'")
+            self.logger.warning("Could not parse Slurm memory: %r", mem_str)
             return 0.0
 
         value = float(match.group(1))
         unit = match.group(2)
+        powers = {"": -1, "K": -1, "M": 0, "G": 1, "T": 2, "P": 3, "E": 4}
+        return value * (1024.0 ** powers[unit])
 
-        if unit == "G":
-            return value * 1024.0
-        if unit == "M":
-            return value
-        if unit == "T":
-            return value * 1024.0 * 1024.0
+    @staticmethod
+    def _parse_number(value: str) -> float:
+        match = re.fullmatch(r"([\d.]+)([KMGTPE]?)", value.strip().upper())
+        if not match:
+            raise ValueError(f"Invalid Slurm numeric value: {value!r}")
+        multipliers = {
+            "": 1.0,
+            "K": 1_000.0,
+            "M": 1_000_000.0,
+            "G": 1_000_000_000.0,
+            "T": 1_000_000_000_000.0,
+            "P": 1_000_000_000_000_000.0,
+            "E": 1_000_000_000_000_000_000.0,
+        }
+        return float(match.group(1)) * multipliers[match.group(2)]
 
-        # Default unit (None or 'K') is Kilobytes, convert to Megabytes
-        return value / 1024.0
-
-    def _parse_exit_code(self, exit_str: str) -> int:
-        """Parse Slurm exit code format (e.g., '0:0' -> 0)."""
-        if not exit_str:
+    @staticmethod
+    def _parse_int(value: str) -> int:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
             return 0
 
+    @staticmethod
+    def _parse_exit_code(exit_str: str) -> int:
+        """Parse Slurm exit code format (for example, ``0:0``)."""
+        if not exit_str:
+            return 0
         try:
-            return int(exit_str.split(":")[0])
+            return int(exit_str.split(":", maxsplit=1)[0])
         except (ValueError, IndexError):
-            return -1  # Return -1 for unparseable exit codes
+            return -1
 
-    def _empty_metrics(self, job_id: int) -> SlurmJobMetrics:
-        """Return empty metrics when collection fails."""
+    @staticmethod
+    def _empty_metrics(job_id: int, *, step_id: str | None = None) -> SlurmJobMetrics:
+        """Return a result that distinguishes unavailable accounting from zero."""
         return SlurmJobMetrics(
             job_id=job_id,
             elapsed_seconds=0.0,
@@ -210,4 +510,6 @@ class SlurmMetricsCollector:
             cpu_efficiency=0.0,
             state="UNKNOWN",
             exit_code=-1,
+            accounting_available=False,
+            step_id=step_id,
         )

--- a/projects/dagster-slurm/dagster_slurm/pipes_clients/slurm_pipes_client.py
+++ b/projects/dagster-slurm/dagster_slurm/pipes_clients/slurm_pipes_client.py
@@ -29,6 +29,7 @@ from dagster import (
     get_dagster_logger,
     open_pipes_session,
 )
+from dagster._core.definitions.metadata import normalize_metadata
 from dagster._core.errors import DagsterPipesExecutionError
 from dagster._core.pipes.client import PipesClientCompletedInvocation
 from dagster._utils.interrupts import _received_interrupt
@@ -37,7 +38,15 @@ from dagster_slurm._compat import tomllib
 
 from ..helpers.env_packaging import compute_env_cache_key, pack_environment_with_pixi
 from ..helpers.message_readers import SSHMessageReader
-from ..helpers.metrics import SlurmMetricsCollector
+from ..helpers.metrics import (
+    DEFAULT_SLURM_METADATA_KEYS,
+    SlurmJobMetrics,
+    SlurmMetricSelection,
+    SlurmMetricsCallback,
+    SlurmMetricsCollector,
+    SlurmMetricsContext,
+    normalize_slurm_metrics,
+)
 from ..helpers.ray_dashboard import RayDashboardLogEmitter
 from ..helpers.ssh_helpers import TERMINAL_STATES, normalize_slurm_state
 from ..helpers.ssh_pool import SSHConnectionPool
@@ -209,6 +218,8 @@ class SlurmPipesClient(PipesClient):
         pre_deployed_env_path_override: Optional[str] = None,
         environment_name: Optional[str] = None,
         extra_files: Optional[list[str]] = None,
+        slurm_metrics: SlurmMetricSelection | None = None,
+        metrics_collector: SlurmMetricsCallback | None = None,
         poll_timeout: int = 3600,
         **kwargs,
     ) -> PipesClientCompletedInvocation:
@@ -229,6 +240,12 @@ class SlurmPipesClient(PipesClient):
             remote_payload_path: Optional pre-existing remote payload path to use when
                 skipping upload.
             environment_name: Named environment prepared by ``project_setup_cmd``.
+            slurm_metrics: Built-in Slurm metadata fields to attach. ``None`` enables
+                all fields; an empty collection disables optional built-in fields.
+            metrics_collector: Optional callback invoked after a standalone Slurm job
+                or shared-allocation step reaches a terminal state. It receives a
+                :class:`SlurmMetricsContext` and returns additional Dagster metadata
+                key-value pairs.
             poll_timeout: Maximum time in seconds to wait for the Slurm job to
                 complete. Defaults to 3600 (1 hour).
             **kwargs: Additional arguments (ignored, for forward compatibility)
@@ -237,6 +254,7 @@ class SlurmPipesClient(PipesClient):
             Dagster events
 
         """
+        enabled_slurm_metrics = normalize_slurm_metrics(slurm_metrics)
         auth_provider = getattr(self.slurm, "_auth_provider", None)
         if auth_provider and callable(getattr(auth_provider, "ensure", None)):
             auth_provider.ensure()
@@ -368,6 +386,8 @@ class SlurmPipesClient(PipesClient):
                                 ssh_pool,
                                 context,
                                 metrics=final_metrics,
+                                slurm_metrics=enabled_slurm_metrics,
+                                custom_metrics_collector=metrics_collector,
                             )
 
                             # Clear tags to prevent stale reattach
@@ -430,6 +450,8 @@ class SlurmPipesClient(PipesClient):
                                 ssh_pool,
                                 context,
                                 metrics=final_metrics,
+                                slurm_metrics=enabled_slurm_metrics,
+                                custom_metrics_collector=metrics_collector,
                             )
 
                             # Clear tags to prevent stale reattach
@@ -633,6 +655,18 @@ class SlurmPipesClient(PipesClient):
                         )
                         if step_result is not None:
                             self._emit_session_metadata(step_result, context)
+                            step_metrics = self._collect_session_step_metrics(
+                                step_result=step_result,
+                                ssh_pool=ssh_pool,
+                            )
+                            self._collect_and_emit_metrics(
+                                job_id,
+                                ssh_pool,
+                                context,
+                                metrics=step_metrics,
+                                slurm_metrics=enabled_slurm_metrics,
+                                custom_metrics_collector=metrics_collector,
+                            )
                     else:
                         final_metrics = self._validate_final_slurm_outcome(
                             job_id,
@@ -646,6 +680,8 @@ class SlurmPipesClient(PipesClient):
                             ssh_pool,
                             context,
                             metrics=final_metrics,
+                            slurm_metrics=enabled_slurm_metrics,
+                            custom_metrics_collector=metrics_collector,
                         )
 
                         # Clear reattach tags so stale tags don't trigger
@@ -1183,19 +1219,26 @@ class SlurmPipesClient(PipesClient):
         ssh_pool: SSHConnectionPool,
         context: Any,
         metrics: Any | None = None,
+        slurm_metrics: SlurmMetricSelection | None = None,
+        custom_metrics_collector: SlurmMetricsCallback | None = None,
     ) -> None:
         """Collect Slurm job metrics via sacct and attach as output metadata."""
         try:
             metrics = metrics or self.metrics_collector.collect_job_metrics(
                 job_id, ssh_pool
             )
-            metadata = {
-                "slurm_job_id": job_id,
-                "node_hours": metrics.node_hours,
-                "cpu_efficiency_pct": round(metrics.cpu_efficiency * 100, 2),
-                "max_memory_mb": round(metrics.max_rss_mb, 2),
-                "elapsed_seconds": round(metrics.elapsed_seconds, 2),
-            }
+            to_metadata = getattr(metrics, "to_metadata", None)
+            if callable(to_metadata):
+                metadata = dict(to_metadata(slurm_metrics))
+            else:
+                metadata = {
+                    "slurm_job_id": job_id,
+                    "node_hours": metrics.node_hours,
+                    "cpu_efficiency_pct": round(metrics.cpu_efficiency * 100, 2),
+                    "max_memory_mb": round(metrics.max_rss_mb, 2),
+                    "elapsed_seconds": round(metrics.elapsed_seconds, 2),
+                }
+
             add_output_metadata = getattr(context, "add_output_metadata", None)
             if not callable(add_output_metadata):
                 self.logger.debug(
@@ -1204,6 +1247,17 @@ class SlurmPipesClient(PipesClient):
                     type(context).__name__,
                 )
                 return
+
+            if custom_metrics_collector is not None:
+                metadata.update(
+                    self._collect_custom_metrics(
+                        collector=custom_metrics_collector,
+                        job_id=job_id,
+                        ssh_pool=ssh_pool,
+                        default_metrics=metrics,
+                        reserved_keys=set(DEFAULT_SLURM_METADATA_KEYS),
+                    )
+                )
 
             # Multi-asset executions require specifying the output name.
             output_names: list[str] = []
@@ -1240,6 +1294,63 @@ class SlurmPipesClient(PipesClient):
         except Exception as e:
             self.logger.warning(f"Failed to collect metrics: {e}")
 
+    def _collect_custom_metrics(
+        self,
+        *,
+        collector: SlurmMetricsCallback,
+        job_id: int,
+        ssh_pool: SSHConnectionPool,
+        default_metrics: Any,
+        reserved_keys: set[str],
+    ) -> dict[str, Any]:
+        """Run and validate a best-effort custom metrics callback."""
+        try:
+            result = collector(
+                SlurmMetricsContext(
+                    job_id=job_id,
+                    ssh_pool=ssh_pool,
+                    slurm_resource=self.slurm,
+                    session_resource=self.session,
+                    default_metrics=default_metrics,
+                    step_id=getattr(default_metrics, "step_id", None),
+                )
+            )
+            if not isinstance(result, Mapping):
+                self.logger.warning(
+                    "Custom Slurm metrics collector for job %s returned %s; "
+                    "expected a mapping.",
+                    job_id,
+                    type(result).__name__,
+                )
+                return {}
+            if not all(isinstance(key, str) for key in result):
+                self.logger.warning(
+                    "Custom Slurm metrics collector for job %s returned a "
+                    "non-string metadata key; ignoring custom metrics.",
+                    job_id,
+                )
+                return {}
+
+            collisions = reserved_keys.intersection(result)
+            if collisions:
+                self.logger.warning(
+                    "Custom Slurm metrics collector for job %s tried to replace "
+                    "reserved metadata keys %s; those values were ignored.",
+                    job_id,
+                    sorted(collisions),
+                )
+            custom_metadata = {
+                key: value for key, value in result.items() if key not in reserved_keys
+            }
+            return dict(normalize_metadata(custom_metadata))
+        except Exception as error:
+            self.logger.warning(
+                "Custom Slurm metrics collector failed for job %s: %s",
+                job_id,
+                error,
+            )
+            return {}
+
     def _emit_session_metadata(
         self, step_result: SlurmStepExecutionResult, context: Any
     ) -> None:
@@ -1254,6 +1365,8 @@ class SlurmPipesClient(PipesClient):
             "slurm_step_stdout_path": step_result.stdout_path,
             "slurm_step_stderr_path": step_result.stderr_path,
         }
+        if step_result.step_id is not None:
+            metadata["slurm_step_id"] = step_result.step_id
 
         output_names: list[str] = []
         if getattr(context, "op_execution_context", None):
@@ -1277,6 +1390,32 @@ class SlurmPipesClient(PipesClient):
         else:
             for output_name in output_names:
                 add_output_metadata(metadata, output_name=output_name)
+
+    def _collect_session_step_metrics(
+        self,
+        *,
+        step_result: SlurmStepExecutionResult,
+        ssh_pool: SSHConnectionPool,
+    ) -> SlurmJobMetrics:
+        """Collect terminal accounting for one step in a live allocation."""
+        if step_result.step_id is None:
+            return SlurmMetricsCollector._empty_metrics(step_result.job_id)
+
+        metrics = SlurmMetricsCollector._empty_metrics(
+            step_result.job_id,
+            step_id=step_result.step_id,
+        )
+        for attempt in range(3):
+            metrics = self.metrics_collector.collect_job_metrics(
+                step_result.job_id,
+                ssh_pool,
+                step_id=step_result.step_id,
+            )
+            if metrics.accounting_available:
+                return metrics
+            if attempt < 2:
+                time.sleep(0.5)
+        return metrics
 
     @staticmethod
     def _parse_slurm_exit_code(exit_code: str) -> tuple[int, int]:
@@ -1303,8 +1442,15 @@ class SlurmPipesClient(PipesClient):
     def _query_final_accounting(self, job_id: int, ssh_pool: SSHConnectionPool) -> str:
         """Fetch every accounting field the completion path needs, once."""
         fmt = self.metrics_collector.SACCT_FORMAT
-        return ssh_pool.run(
+        output = ssh_pool.run(
             f"sacct -j {job_id} -n -P --format={fmt} 2>/dev/null || true"
+        ).strip()
+        if output or not hasattr(self.metrics_collector, "BASE_SACCT_FORMAT"):
+            return output
+        return ssh_pool.run(
+            f"sacct -j {job_id} -n -P "
+            f"--format={self.metrics_collector.BASE_SACCT_FORMAT} "
+            "2>/dev/null || true"
         ).strip()
 
     @staticmethod

--- a/projects/dagster-slurm/dagster_slurm/resources/compute.py
+++ b/projects/dagster-slurm/dagster_slurm/resources/compute.py
@@ -10,6 +10,7 @@ from dagster._core.pipes.client import PipesClientCompletedInvocation
 
 from ..config.environment import ExecutionMode
 from ..config.runtime import SlurmRunConfig
+from ..helpers.metrics import SlurmMetricSelection, SlurmMetricsCallback
 from ..helpers.ssh_pool import SSHConnectionPool
 from ..launchers.base import ComputeLauncher
 from ..launchers.ray import RayLauncher
@@ -884,7 +885,9 @@ class ComputeResource(ConfigurableResource):
         environment_name: Optional[str] = None,
         config: Optional[SlurmRunConfig] = None,
         extra_files: Optional[List[str]] = None,
+        metrics_collector: Optional[SlurmMetricsCallback] = None,
         poll_timeout: int = 3600,
+        slurm_metrics: SlurmMetricSelection | None = None,
         **kwargs,
     ) -> PipesClientCompletedInvocation:
         """Execute asset with optional resource overrides.
@@ -919,8 +922,15 @@ class ComputeResource(ConfigurableResource):
                 Values from config are used as defaults, but explicit parameters take precedence.
             extra_files: List of local file paths to upload alongside the payload.
                 Merged with default_extra_files, asset metadata, and config.extra_files.
+            metrics_collector: Optional callback that receives a
+                :class:`SlurmMetricsContext` after a standalone Slurm job or
+                shared-allocation step finishes and returns custom Dagster metadata
+                key-value pairs. Callback errors and invalid metadata are logged
+                without failing the workload.
             poll_timeout: Maximum time in seconds to wait for the Slurm job to
                 complete. Defaults to 3600 (1 hour).
+            slurm_metrics: Built-in Slurm metadata fields to attach. ``None`` enables
+                all fields; an empty collection disables optional built-in fields.
             **kwargs: Passed to client.run()
 
         Yields:
@@ -1065,6 +1075,10 @@ class ComputeResource(ConfigurableResource):
             kwargs["force_env_push"] = resolved_force_env_push
             kwargs["skip_payload_upload"] = skip_payload_upload_resolved
             kwargs["poll_timeout"] = poll_timeout
+            if slurm_metrics is not None:
+                kwargs["slurm_metrics"] = slurm_metrics
+            if metrics_collector is not None:
+                kwargs["metrics_collector"] = metrics_collector
             if resolved_remote_payload_path:
                 kwargs["remote_payload_path"] = resolved_remote_payload_path
             if pack_cmd_override:

--- a/projects/dagster-slurm/dagster_slurm/resources/session.py
+++ b/projects/dagster-slurm/dagster_slurm/resources/session.py
@@ -225,6 +225,7 @@ class SlurmStepExecutionResult:
     job_id: int
     stdout_path: str
     stderr_path: str
+    step_id: str | None = None
 
 
 class SlurmSessionResource(ConfigurableResource):
@@ -839,13 +840,19 @@ class SlurmAllocation:
             for aux_name, aux_content in auxiliary_scripts.items()
         ]
 
-        script_lines = execution_plan.payload
-
         safe_asset_key = re.sub(r"[^A-Za-z0-9_.=-]+", "_", asset_key).strip("._-")
         if not safe_asset_key:
             safe_asset_key = "asset"
         script_name = f"asset_{exec_id}_{safe_asset_key}.sh"
         script_path = f"{run_dir}/{script_name}"
+        step_id_path = f"{run_dir}/.slurm-step-{exec_id}.id"
+        step_id_capture = (
+            'printf \'%s.%s\\n\' "${SLURM_JOB_ID:?}" "${SLURM_STEP_ID:?}" > '
+            f"{shlex.quote(step_id_path)}"
+        )
+        script_lines = list(execution_plan.payload)
+        capture_index = 1 if script_lines and script_lines[0].startswith("#!") else 0
+        script_lines.insert(capture_index, step_id_capture)
         ssh_pool.write_file("\n".join(script_lines), script_path)
         ssh_pool.run(f"chmod +x {shlex.quote(script_path)}")
 
@@ -882,10 +889,22 @@ class SlurmAllocation:
             f"Execution {exec_id} in allocation {self.slurm_job_id} completed"
         )
 
+        step_id = ssh_pool.run(
+            f"cat {shlex.quote(step_id_path)} 2>/dev/null || true"
+        ).strip()
+        if not re.fullmatch(rf"{self.slurm_job_id}\.[A-Za-z0-9_+-]+", step_id):
+            self.logger.warning(
+                "Could not determine Slurm step ID for execution %s in allocation %s",
+                exec_id,
+                self.slurm_job_id,
+            )
+            step_id = None
+
         return SlurmStepExecutionResult(
             job_id=self.slurm_job_id,
             stdout_path=stdout_path,
             stderr_path=stderr_path,
+            step_id=step_id,
         )
 
     def ensure_ray_cluster(

--- a/projects/dagster-slurm/dagster_slurm_test/test_metrics.py
+++ b/projects/dagster-slurm/dagster_slurm_test/test_metrics.py
@@ -4,9 +4,17 @@ from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock
 
-from dagster_slurm import BashLauncher
-from dagster_slurm.helpers.metrics import SlurmJobMetrics, SlurmMetricsCollector
+import pytest
+from dagster import FloatMetadataValue
+
+from dagster_slurm import BashLauncher, SlurmMetric, SlurmMetricsContext
+from dagster_slurm.helpers.metrics import (
+    SlurmJobMetrics,
+    SlurmMetricsCollector,
+    normalize_slurm_metrics,
+)
 from dagster_slurm.pipes_clients.slurm_pipes_client import SlurmPipesClient
+from dagster_slurm.resources.session import SlurmStepExecutionResult
 
 
 def test_parse_time():
@@ -39,10 +47,280 @@ def test_parse_exit_code():
     assert collector._parse_exit_code("127:15") == 127
 
 
+def test_collect_job_metrics_includes_gpu_tres_and_raw_step_rows():
+    sacct_output = "\n".join(
+        (
+            "123|00:10:00|00:40:00|2048M|2|8|COMPLETED|0:0|node[01-02]|"
+            "cpu=8,gres/gpu=4|cpu=8,gres/gpu=4|||||",
+            "123.batch|00:10:00|00:40:00|2048M|2|8|COMPLETED|0:0|node[01-02]|"
+            "cpu=8,gres/gpu=4|cpu=8,gres/gpu=4|"
+            "gres/gpumem=4G,gres/gpuutil=37.5|"
+            "gres/gpumem=8G,gres/gpuutil=92|"
+            "gres/gpuutil=node02|gres/gpuutil=3|"
+            "gres/gpumem=12G,gres/gpuutil=150",
+        )
+    )
+
+    metrics = SlurmMetricsCollector().collect_job_metrics(
+        job_id=123,
+        ssh_pool=MagicMock(),
+        sacct_output=sacct_output,
+    )
+
+    assert metrics.accounting_available is True
+    assert metrics.requested_gpus == 4
+    assert metrics.allocated_gpus == 4
+    assert metrics.gpu_utilization_avg_pct == 37.5
+    assert metrics.gpu_utilization_max_pct == 92.0
+    assert metrics.gpu_memory_max_mb == 8192.0
+    assert metrics.gpu_utilization_max_node == "node02"
+    assert len(metrics.accounting_rows) == 2
+    assert metrics.accounting_rows[1]["TRESUsageInMaxTask"] == "gres/gpuutil=3"
+
+    metadata = metrics.to_metadata()
+    assert metadata["slurm_gpu_accounting_available"] is True
+    assert metadata["slurm_gpu_utilization_avg_pct"] == 37.5
+    assert metadata["slurm_gpu_memory_max_mb"] == 8192.0
+
+
+def test_slurm_metric_selection_defaults_to_all_and_filters_optional_metadata():
+    metrics = SlurmJobMetrics(
+        job_id=123,
+        step_id="123.7",
+        elapsed_seconds=60.0,
+        cpu_time_seconds=30.0,
+        max_rss_mb=1.0,
+        node_hours=1 / 60,
+        cpu_efficiency=0.5,
+        state="COMPLETED",
+        exit_code=0,
+        gpu_utilization_avg_pct=40.0,
+        gpu_memory_max_mb=3072.0,
+    )
+
+    assert "cpu_efficiency_pct" in metrics.to_metadata()
+    assert metrics.to_metadata(
+        {
+            SlurmMetric.GPU_UTILIZATION_AVG,
+            "slurm_gpu_memory_max_mb",
+        }
+    ) == {
+        "slurm_job_id": 123,
+        "slurm_step_id": "123.7",
+        "slurm_accounting_available": True,
+        "slurm_gpu_utilization_avg_pct": 40.0,
+        "slurm_gpu_memory_max_mb": 3072.0,
+    }
+    assert metrics.to_metadata([]) == {
+        "slurm_job_id": 123,
+        "slurm_step_id": "123.7",
+        "slurm_accounting_available": True,
+    }
+
+
+def test_slurm_metric_selection_rejects_unknown_values():
+    with pytest.raises(ValueError, match="Unknown Slurm metric"):
+        normalize_slurm_metrics(["gpu_temperature"])
+
+
+def test_collect_and_emit_metrics_honors_slurm_metric_selection():
+    client = SlurmPipesClient(
+        slurm_resource=cast(Any, SimpleNamespace(ssh=None, queue=None)),
+        launcher=BashLauncher(),
+    )
+    add_output_metadata = MagicMock()
+
+    client._collect_and_emit_metrics(
+        job_id=123,
+        ssh_pool=MagicMock(),
+        context=SimpleNamespace(add_output_metadata=add_output_metadata),
+        metrics=SlurmJobMetrics(
+            job_id=123,
+            elapsed_seconds=60.0,
+            cpu_time_seconds=30.0,
+            max_rss_mb=1.0,
+            node_hours=1 / 60,
+            cpu_efficiency=0.5,
+            state="COMPLETED",
+            exit_code=0,
+        ),
+        slurm_metrics=[SlurmMetric.STATE],
+    )
+
+    assert add_output_metadata.call_args.args[0] == {
+        "slurm_job_id": 123,
+        "slurm_accounting_available": True,
+        "slurm_state": "COMPLETED",
+    }
+
+
+def test_collect_job_metrics_distinguishes_unavailable_accounting_from_zero():
+    ssh_pool = MagicMock()
+    ssh_pool.run.side_effect = ["", ""]
+
+    metrics = SlurmMetricsCollector().collect_job_metrics(123, ssh_pool)
+
+    assert metrics.accounting_available is False
+    assert metrics.gpu_utilization_avg_pct is None
+    assert metrics.to_metadata() == {
+        "slurm_job_id": 123,
+        "slurm_accounting_available": False,
+    }
+    assert ssh_pool.run.call_count == 2
+
+
+def test_collect_job_metrics_preserves_reported_zero_gpu_utilization():
+    sacct_output = (
+        "123.batch|00:01:00|00:00:30|1024K|1|1|COMPLETED|0:0|node01|"
+        "gres/gpu=1|gres/gpu=1|gres/gpumem=0,gres/gpuutil=0|"
+        "gres/gpumem=0,gres/gpuutil=0|gres/gpuutil=node01|"
+        "gres/gpuutil=0|gres/gpumem=0,gres/gpuutil=0"
+    )
+
+    metrics = SlurmMetricsCollector().collect_job_metrics(
+        job_id=123,
+        ssh_pool=MagicMock(),
+        sacct_output=sacct_output,
+    )
+
+    assert metrics.accounting_available is True
+    assert metrics.gpu_accounting_available is True
+    assert metrics.gpu_utilization_avg_pct == 0.0
+    assert metrics.gpu_memory_max_mb == 0.0
+
+
+def test_collect_job_metrics_accepts_base_sacct_fallback_without_gpu_fields():
+    metrics = SlurmMetricsCollector().collect_job_metrics(
+        job_id=123,
+        ssh_pool=MagicMock(),
+        sacct_output="123.batch|00:01:00|00:00:30|1024K|1|1|COMPLETED|0:0",
+    )
+
+    assert metrics.accounting_available is True
+    assert metrics.max_rss_mb == 1.0
+    assert metrics.gpu_accounting_available is False
+    assert metrics.requested_gpus is None
+
+
+def test_collect_session_step_metrics_queries_completed_step():
+    client = SlurmPipesClient(
+        slurm_resource=cast(Any, SimpleNamespace(ssh=None, queue=None)),
+        launcher=BashLauncher(),
+    )
+    ssh_pool = MagicMock()
+    ssh_pool.run.return_value = (
+        "123.7|00:01:00|00:00:30|1024K|1|1|COMPLETED|0:0|node01|"
+        "gres/gpu=1|gres/gpu=1|gres/gpumem=2G,gres/gpuutil=40|"
+        "gres/gpumem=3G,gres/gpuutil=80|gres/gpuutil=node01|"
+        "gres/gpuutil=0|gres/gpumem=3G,gres/gpuutil=80"
+    )
+
+    metrics = client._collect_session_step_metrics(
+        step_result=SlurmStepExecutionResult(
+            job_id=123,
+            step_id="123.7",
+            stdout_path="/tmp/stdout",
+            stderr_path="/tmp/stderr",
+        ),
+        ssh_pool=ssh_pool,
+    )
+
+    assert metrics.step_id == "123.7"
+    assert metrics.gpu_utilization_avg_pct == 40.0
+    assert "sacct -j 123.7" in ssh_pool.run.call_args.args[0]
+    assert metrics.to_metadata()["slurm_step_id"] == "123.7"
+
+
+def test_collect_job_metrics_uses_step_average_in_shared_allocation():
+    sacct_output = "\n".join(
+        (
+            "123|00:10:00|00:40:00|2048M|2|8|RUNNING|0:0|node[01-02]|"
+            "gres/gpu=4|gres/gpu=4|gres/gpuutil=10|||||",
+            "123.7|00:01:00|00:00:30|1024K|1|1|COMPLETED|0:0|node01|"
+            "gres/gpu=1|gres/gpu=1|gres/gpuutil=40|gres/gpuutil=80|"
+            "gres/gpuutil=node01|gres/gpuutil=0|gres/gpuutil=40",
+        )
+    )
+
+    metrics = SlurmMetricsCollector().collect_job_metrics(
+        job_id=123,
+        step_id="123.7",
+        ssh_pool=MagicMock(),
+        sacct_output=sacct_output,
+    )
+
+    assert metrics.gpu_utilization_avg_pct == 40.0
+
+
+def test_custom_metrics_collector_receives_context_and_emits_metadata():
+    client = SlurmPipesClient(
+        slurm_resource=cast(Any, SimpleNamespace(ssh=None, queue=None)),
+        launcher=BashLauncher(),
+    )
+    add_output_metadata = MagicMock()
+    context = SimpleNamespace(add_output_metadata=add_output_metadata)
+    ssh_pool = MagicMock()
+    prefix = "site"
+
+    def collect(metrics_context: SlurmMetricsContext):
+        assert metrics_context.job_id == 123
+        assert metrics_context.ssh_pool is ssh_pool
+        assert metrics_context.slurm_resource is client.slurm
+        assert metrics_context.step_id == "123.7"
+        return {
+            f"{prefix}/energy_joules": 42.5,
+            f"{prefix}/scheduler": "slurmdbd",
+        }
+
+    client._collect_and_emit_metrics(
+        job_id=123,
+        ssh_pool=ssh_pool,
+        context=context,
+        metrics=SlurmMetricsCollector._empty_metrics(123, step_id="123.7"),
+        custom_metrics_collector=collect,
+    )
+
+    emitted_metadata = add_output_metadata.call_args.args[0]
+    assert emitted_metadata["slurm_accounting_available"] is False
+    assert emitted_metadata["slurm_step_id"] == "123.7"
+    assert emitted_metadata["site/scheduler"].value == "slurmdbd"
+    assert isinstance(emitted_metadata["site/energy_joules"], FloatMetadataValue)
+    assert emitted_metadata["site/energy_joules"].value == 42.5
+
+
+def test_invalid_custom_metrics_do_not_hide_default_metrics():
+    client = SlurmPipesClient(
+        slurm_resource=cast(Any, SimpleNamespace(ssh=None, queue=None)),
+        launcher=BashLauncher(),
+    )
+    client.logger = MagicMock()
+    add_output_metadata = MagicMock()
+
+    client._collect_and_emit_metrics(
+        job_id=123,
+        ssh_pool=MagicMock(),
+        context=SimpleNamespace(add_output_metadata=add_output_metadata),
+        metrics=SlurmMetricsCollector._empty_metrics(123),
+        custom_metrics_collector=lambda _: {
+            "slurm_job_id": 999,
+            "site/invalid": object(),
+        },
+    )
+
+    emitted_metadata = add_output_metadata.call_args.args[0]
+    assert emitted_metadata["slurm_job_id"] == 123
+    assert "site/invalid" not in emitted_metadata
+    client.logger.warning.assert_called()
+
+
 def test_collect_and_emit_metrics_skips_contexts_without_output_metadata():
     class FakeMetricsCollector(SlurmMetricsCollector):
         def collect_job_metrics(
-            self, job_id: int, ssh_pool, sacct_output: str | None = None
+            self,
+            job_id: int,
+            ssh_pool,
+            sacct_output: str | None = None,
+            step_id: str | None = None,
         ) -> SlurmJobMetrics:
             return SlurmJobMetrics(
                 job_id=job_id,
@@ -63,11 +341,14 @@ def test_collect_and_emit_metrics_skips_contexts_without_output_metadata():
     client.metrics_collector = FakeMetricsCollector()
 
     asset_check_context = SimpleNamespace(op_execution_context=SimpleNamespace())
+    custom_metrics_collector = MagicMock(return_value={"unused": 1})
 
     client._collect_and_emit_metrics(
         job_id=1234,
         ssh_pool=MagicMock(),
         context=asset_check_context,
+        custom_metrics_collector=custom_metrics_collector,
     )
 
     client.logger.warning.assert_not_called()
+    custom_metrics_collector.assert_not_called()

--- a/projects/dagster-slurm/dagster_slurm_test/test_resources.py
+++ b/projects/dagster-slurm/dagster_slurm_test/test_resources.py
@@ -344,6 +344,10 @@ def test_slurm_allocation_execute_uses_per_step_log_paths():
 
         def run(self, cmd: str):
             self.commands.append(cmd)
+            if ".slurm-step-1.id" in cmd:
+                return "42.7"
+            if ".slurm-step-2.id" in cmd:
+                return "42.8"
             return ""
 
     session = SlurmSessionResource(slurm=_mock_slurm_resource())
@@ -381,7 +385,9 @@ def test_slurm_allocation_execute_uses_per_step_log_paths():
     assert first.stdout_path.endswith("slurm-42-step-1_asset_one.out")
     assert second.stdout_path.endswith("slurm-42-step-2_asset_two.out")
     assert first.stdout_path in fake_ssh_pool.commands[1]
-    assert second.stdout_path in fake_ssh_pool.commands[3]
+    assert second.stdout_path in fake_ssh_pool.commands[4]
+    assert first.step_id == "42.7"
+    assert second.step_id == "42.8"
 
 
 def test_slurm_session_allocation_honors_zero_gpu_override(monkeypatch):
@@ -830,6 +836,8 @@ def test_slurm_allocation_accepts_safe_auxiliary_script_names():
 
         def run(self, cmd: str):
             self.commands.append(cmd)
+            if cmd.startswith("cat /remote/run/.slurm-step-1.id"):
+                return "42.7"
             return ""
 
     allocation = SlurmAllocation(
@@ -850,7 +858,7 @@ def test_slurm_allocation_accepts_safe_auxiliary_script_names():
     )
     fake_ssh_pool = FakeSSHPool()
 
-    allocation.execute(
+    result = allocation.execute(
         plan,
         asset_key="asset",
         run_dir="/remote/run",
@@ -863,9 +871,13 @@ def test_slurm_allocation_accepts_safe_auxiliary_script_names():
         "/remote/run/ray_driver.sh",
         "/remote/run/ray_worker-1.sh",
     ]
-    assert fake_ssh_pool.commands[-1].startswith(
+    assert fake_ssh_pool.commands[-2].startswith(
         "srun --overlap --jobid=42 --job-name=asset_1"
     )
+    asset_script = fake_ssh_pool.writes[0][1].splitlines()
+    assert asset_script[0] == "#!/bin/bash"
+    assert "${SLURM_STEP_ID:?}" in asset_script[1]
+    assert result.step_id == "42.7"
 
 
 def test_slurm_allocation_srun_failure_reports_step_logs():


### PR DESCRIPTION
## Summary

- collect requested and allocated GPUs plus `gpuutil` and `gpumem` TRES summaries from `sacct` by default
- keep every built-in metric enabled by default; allow per-run subsets through `slurm_metrics` and the typed `SlurmMetric` enum
- preserve raw job and step TRES rows for multi-node auditability
- distinguish unavailable accounting from a reported zero; fall back to the portable base `sacct` format
- support custom functions, lambdas, and closures that return validated Dagster metadata
- attribute metrics to each completed `srun` step when assets share one live allocation
- document the persistent-Ray limitation: GPU work belongs to long-lived worker steps and needs a Ray/NVML collector for per-asset attribution

## Validation

- 252 non-Slurm unit tests passed
- Ruff, dprint, and ty passed
- Docusaurus production build passed

Closes #189