### PR TITLE
fix: assign Ray client port on worker nodes

### DIFF
--- a/projects/dagster-slurm/dagster_slurm/launchers/ray.py
+++ b/projects/dagster-slurm/dagster_slurm/launchers/ray.py
@@ -825,6 +825,7 @@ class RayLauncher(ComputeLauncher):
             "--redis-password=$redis_password",
             "--node-manager-port=$node_manager_port",
             "--object-manager-port=$object_manager_port",
+            "--ray-client-server-port=$ray_client_server_port",
             "--runtime-env-agent-port=$runtime_env_agent_port",
             "--dashboard-agent-grpc-port=$dashboard_agent_grpc_port",
             "--dashboard-agent-listen-port=$dashboard_agent_listen_port",

--- a/projects/dagster-slurm/dagster_slurm/resources/session.py
+++ b/projects/dagster-slurm/dagster_slurm/resources/session.py
@@ -1360,6 +1360,7 @@ wait "$RAY_HEAD_PID"
 {worker_node_ip_arg}\
 	  --node-manager-port="$node_manager_port" \
 	  --object-manager-port="$object_manager_port" \
+	  --ray-client-server-port="$ray_client_server_port" \
 	  --runtime-env-agent-port="$runtime_env_agent_port" \
 	  --dashboard-agent-grpc-port="$dashboard_agent_grpc_port" \
 	  --dashboard-agent-listen-port="$dashboard_agent_listen_port" \

--- a/projects/dagster-slurm/dagster_slurm_test/test_launchers.py
+++ b/projects/dagster-slurm/dagster_slurm_test/test_launchers.py
@@ -450,6 +450,7 @@ def test_ray_launcher_cluster_standalone_mode():
 
     assert "--address=$ip_head" in worker_script
     assert "--num-gpus=2" in worker_script
+    assert "--ray-client-server-port=$ray_client_server_port" in worker_script
     assert "--node-ip-address" not in worker_script
     assert "trap - EXIT INT TERM" in worker_script
     assert 'exit "$exit_code"' in worker_script

--- a/projects/dagster-slurm/dagster_slurm_test/test_resources.py
+++ b/projects/dagster-slurm/dagster_slurm_test/test_resources.py
@@ -956,6 +956,7 @@ def test_persistent_ray_scripts_use_node_local_temp_dirs_and_hostname_address():
     assert 'rm -rf "$RAY_TMP_DIR"' in head_script
 
     assert '--temp-dir="$RAY_TMP_DIR"' in worker_script
+    assert '--ray-client-server-port="$ray_client_server_port"' in worker_script
     assert 'export RAY_TMPDIR="${RAY_TMP_DIR}"' in worker_script
     assert 'rm -rf "$RAY_TMP_DIR"' in worker_script
 


### PR DESCRIPTION
## Summary

- assign the dynamically selected Ray client-server port to worker nodes
- apply the same worker configuration to persistent run-scoped allocations
- cover both generated worker scripts with regression assertions

This prevents Ray workers from reusing the default client port 10001 as their dynamically assigned node-manager port.

Regression: https://github.com/ascii-supply-networks/dagster-slurm/actions/runs/30745433228/job/91490117921

## Verification

- 252 unit tests passed
- launcher/resource tests: 66 passed
- lint, formatting, and type checks passed
- Slurm Docker integration tests run in CI