### PR TITLE
fix: tolerate delayed Ray worker registration

### DIFF
--- a/projects/dagster-slurm/dagster_slurm/launchers/ray.py
+++ b/projects/dagster-slurm/dagster_slurm/launchers/ray.py
@@ -1040,7 +1040,7 @@ class RayLauncher(ComputeLauncher):
             echo "PAYLOAD FAILED OR SCRIPT EXITED UNEXPECTEDLY! Capturing logs..." >&2
             for node in "${{worker_nodes[@]}}"; do
                 echo "--- WORKER NODE ($node) RAYLET LOG ---" >&2
-                srun --cpu-bind=none --nodes=1 --ntasks=1 -w "$node" bash -c 'tail -n 50 $(find $RAY_CLUSTER_TMP/session_*/logs/raylet.out -type f 2>/dev/null | sort | tail -n 1)' || echo "Worker log on $node not found." >&2
+                timeout 10s srun --overlap --cpu-bind=none --nodes=1 --ntasks=1 -w "$node" bash -c 'tail -n 50 $(find $RAY_CLUSTER_TMP/session_*/logs/raylet.out -type f 2>/dev/null | sort | tail -n 1)' || echo "Worker log on $node not found." >&2
             done
             echo "--- HEAD NODE ($(hostname)) RAYLET LOG ---" >&2
             tail -n 50 $(find $RAY_CLUSTER_TMP/session_*/logs/raylet.out -type f 2>/dev/null | sort | tail -n 1) || echo "Head raylet log not found." >&2
@@ -1168,7 +1168,7 @@ class RayLauncher(ComputeLauncher):
         # This is the robust way: capture output first, then grep it.
         # This prevents grep's non-zero exit code from triggering 'set -e'.
         status_output=$(ray status 2>/dev/null || echo "ray status failed")
-        live_nodes=$(echo "$status_output" | grep -c "node_")
+        live_nodes=$(echo "$status_output" | grep -c "node_" || true)
 
         if [[ "$live_nodes" -ge "$expected_nodes" ]]; then
             echo "✓ Success! $live_nodes of $expected_nodes nodes are active."

--- a/projects/dagster-slurm/dagster_slurm_test/test_launchers.py
+++ b/projects/dagster-slurm/dagster_slurm_test/test_launchers.py
@@ -440,6 +440,10 @@ def test_ray_launcher_cluster_standalone_mode():
     )
     assert "ray start --head" in driver_script
     assert "--node-ip-address=$head_bind_addr" in driver_script
+    assert (
+        'live_nodes=$(echo "$status_output" | grep -c "node_" || true)' in driver_script
+    )
+    assert "timeout 10s srun --overlap --cpu-bind=none" in driver_script
     assert 'srun --cpu-bind=none --nodes=1 --ntasks=1 -w "$node_i"' in driver_script
     assert "/remote/env/bin/python /path/to/script.py" in driver_script
     assert "trap - EXIT SIGINT SIGTERM" in driver_script


### PR DESCRIPTION
## Summary

- allow the Ray registration loop to observe zero nodes without exiting under shell strict mode
- collect worker diagnostics with a bounded overlapping Slurm step
- prevent a failed Ray startup from retaining the allocation and blocking later jobs

Root cause: the first registration poll raced worker registration. A zero-match grep terminated the driver, then diagnostic srun waited behind the still-running worker step.

Regression: https://github.com/ascii-supply-networks/dagster-slurm/actions/runs/30746434531/job/91492729304

## Verification

- 252 unit tests passed
- launcher tests: 11 passed
- lint, formatting, and type checks passed
- Slurm Docker integration tests run in CI