### PR TITLE
fix: preserve workload exit after pre-timeout signal

### DIFF
--- a/projects/dagster-slurm/dagster_slurm/pipes_clients/slurm_pipes_client.py
+++ b/projects/dagster-slurm/dagster_slurm/pipes_clients/slurm_pipes_client.py
@@ -2729,10 +2729,14 @@ _dagster_slurm_workload_exit=0
 while true; do
   wait "$_dagster_slurm_workload_pid"
   _dagster_slurm_wait_exit=$?
-  if ! kill -0 "$_dagster_slurm_workload_pid" 2>/dev/null; then
-    _dagster_slurm_workload_exit=$_dagster_slurm_wait_exit
-    break
+  if [[ "$_dagster_slurm_signal_received" -eq 1 ]]; then
+    # The trap interrupts wait with 128+signal even when the workload's own
+    # handler exits cleanly. Wait again to reap the workload's real status.
+    _dagster_slurm_signal_received=0
+    continue
   fi
+  _dagster_slurm_workload_exit=$_dagster_slurm_wait_exit
+  break
 done
 
 trap - "$_dagster_slurm_signal"

--- a/projects/dagster-slurm/dagster_slurm_test/test_resources.py
+++ b/projects/dagster-slurm/dagster_slurm_test/test_resources.py
@@ -1197,6 +1197,19 @@ def test_workload_exit_code_survives_the_signal(slurm_pipes_client, tmp_path: Pa
     assert marker == "USR1"
 
 
+def test_workload_immediate_signal_exit_is_reaped(slurm_pipes_client, tmp_path: Path):
+    """A fast signal handler must not expose the interrupted wait status."""
+    return_code, marker = _run_pre_timeout_supervisor(
+        slurm_pipes_client,
+        tmp_path,
+        ['trap "exit 0" USR1', "while true; do sleep 0.01; done"],
+        send_signal=True,
+    )
+
+    assert return_code == 0
+    assert marker == "USR1"
+
+
 def test_workload_ignoring_the_signal_still_fails(slurm_pipes_client, tmp_path: Path):
     """An unhandled signal kills the workload, which stays a failure."""
     return_code, marker = _run_pre_timeout_supervisor(


### PR DESCRIPTION
## Summary

- Reap the workload again after the supervisor signal trap interrupts `wait`.
- Preserve the workload handler’s real exit code instead of the transient `128 + signal` status.
- Cover a signal handler that exits immediately with zero.

## Root cause

Bash returns 138 when USR1 interrupts `wait`. If the workload exited before the following liveness check, the wrapper treated 138 as the workload exit code even though its handler returned zero.

Failure: https://github.com/ascii-supply-networks/dagster-slurm/actions/runs/30747659795/job/91495926620

## Validation

- 253 unit tests passed
- Ruff, dprint, and ty passed
- Docker/Slurm integration runs in CI