### PR TITLE
fix: avoid duplicate stdio events

### DIFF
--- a/projects/dagster-slurm/dagster_slurm/helpers/message_readers.py
+++ b/projects/dagster-slurm/dagster_slurm/helpers/message_readers.py
@@ -429,10 +429,6 @@ class SSHMessageReader(PipesMessageReader):
                                         line_count = max(line_count, 1)
                                     if line_count:
                                         self._forwarded_lines[stream] += line_count
-                                self.logger.debug(
-                                    "SSHMessageReader stdio chunk: %s",
-                                    message.get("params", {}).get("text", "")[:200],
-                                )
                             handler.handle_message(message)
                             message_count += 1
                             total_message_count += 1
@@ -496,10 +492,6 @@ class SSHMessageReader(PipesMessageReader):
                                         line_count = max(line_count, 1)
                                     if line_count:
                                         self._forwarded_lines[stream] += line_count
-                                self.logger.debug(
-                                    "SSHMessageReader stdio chunk: %s",
-                                    message.get("params", {}).get("text", "")[:200],
-                                )
                             handler.handle_message(message)
                             message_count += 1
                             total_message_count += 1
@@ -665,10 +657,6 @@ class SSHMessageReader(PipesMessageReader):
                                         line_count = max(line_count, 1)
                                     if line_count:
                                         self._forwarded_lines[stream] += line_count
-                                self.logger.debug(
-                                    "SSHMessageReader stdio chunk (fallback): %s",
-                                    message.get("params", {}).get("text", "")[:200],
-                                )
                             handler.handle_message(message)
                             message_count += 1
                             total_message_count += 1

--- a/projects/dagster-slurm/dagster_slurm_test/test_resources.py
+++ b/projects/dagster-slurm/dagster_slurm_test/test_resources.py
@@ -770,6 +770,52 @@ def test_final_log_fallback_shell_quotes_remote_paths():
     assert "; cat /remote" not in command
 
 
+def test_final_log_fallback_skips_forwarded_lines(capsys: pytest.CaptureFixture[str]):
+    slurm = _mock_slurm_resource()
+    client = SlurmPipesClient(slurm_resource=slurm, launcher=BashLauncher())
+    reader = SSHMessageReader(
+        remote_path="/remote/run/messages.jsonl",
+        ssh_config=slurm.ssh,
+    )
+    reader._forwarded_lines = {"stdout": 2, "stderr": 1}
+    stdout_path = "/remote/run/slurm-123.out"
+    stderr_path = "/remote/run/slurm-123.err"
+
+    class FakeSSHPool:
+        def run(self, cmd: str) -> str:
+            first_print = cmd.split("; ", maxsplit=1)[0]
+            first_marker_path = shlex.split(first_print)[2]
+            marker = first_marker_path.removesuffix(stdout_path)
+            return "\n".join(
+                [
+                    f"{marker}{stdout_path}",
+                    "already forwarded stdout 1",
+                    "already forwarded stdout 2",
+                    "remaining stdout 1",
+                    "remaining stdout 2",
+                    f"{marker}{stderr_path}",
+                    "already forwarded stderr",
+                    "remaining stderr",
+                ]
+            )
+
+    client._maybe_emit_final_logs(
+        message_reader=reader,
+        ssh_pool=cast(SSHConnectionPool, FakeSSHPool()),
+        run_dir="/remote/run",
+        job_id=123,
+        stdout_path=stdout_path,
+        stderr_path=stderr_path,
+    )
+
+    captured = capsys.readouterr()
+    assert captured.out == (
+        "[SLURM STDOUT fallback] remaining stdout 1\n"
+        "[SLURM STDOUT fallback] remaining stdout 2\n"
+    )
+    assert captured.err == "[SLURM STDERR fallback] remaining stderr\n"
+
+
 @pytest.mark.parametrize(
     "auxiliary_script_name",
     [


### PR DESCRIPTION
## Summary

- stop emitting remote stdout and stderr payloads as per-message Dagster DEBUG events across native SSH, password/pexpect, and polling transports
- preserve the existing Pipes handler forwarding and `_forwarded_lines` accounting
- add regression coverage proving final Slurm log fallback skips lines already forwarded for both stdout and stderr

## Tests

- `python -m pytest -m "not (needs_slurm_docker or slow)" projects` (254 passed, 19 deselected)
- `ruff check` and `ruff format --check` on changed files
- `dprint check`
- `ty check projects/dagster-slurm/dagster_slurm projects/dagster-slurm/dagster_slurm_test`

Closes #197