### PR TITLE
fix: defer run_dir cleanup for callers that reuse a session across run() calls

### DIFF
--- a/projects/dagster-slurm/dagster_slurm/pipes_clients/slurm_pipes_client.py
+++ b/projects/dagster-slurm/dagster_slurm/pipes_clients/slurm_pipes_client.py
@@ -221,6 +221,7 @@ class SlurmPipesClient(PipesClient):
         slurm_metrics: SlurmMetricSelection | None = None,
         metrics_collector: SlurmMetricsCallback | None = None,
         poll_timeout: int = 3600,
+        defer_cleanup: bool = False,
         **kwargs,
     ) -> PipesClientCompletedInvocation:
         """Execute payload on Slurm cluster with real-time log streaming.
@@ -248,6 +249,21 @@ class SlurmPipesClient(PipesClient):
                 key-value pairs.
             poll_timeout: Maximum time in seconds to wait for the Slurm job to
                 complete. Defaults to 3600 (1 hour).
+            defer_cleanup: If True, skip the async ``run_dir`` cleanup this call
+                would otherwise trigger (on success, on a reattach outcome, and
+                on failure) and leave it for the caller to remove later via
+                :meth:`cleanup_deferred_run_dir`. ``run_dir`` is deterministic
+                per Dagster step/partition/mapping (see ``_get_remote_run_dir``),
+                not per call, so a caller that invokes ``run()`` repeatedly for
+                one step against the same allocation/session (e.g. a per-wave
+                loop that intentionally reuses one ``SlurmPipesClient``-backed
+                ``ComputeResource`` across many ``run()`` calls) would otherwise
+                have each call's fire-and-forget ``nohup rm -rf <run_dir> &``
+                race the *next* call's ``mkdir -p``/upload into that same,
+                still-being-deleted directory -- a real, unsynchronized
+                delete-vs-recreate race, not merely wasted re-staging work.
+                Defaults to False so every existing caller (one ``run()`` call
+                per directory) is unaffected.
             **kwargs: Additional arguments (ignored, for forward compatibility)
 
         Yields:
@@ -400,7 +416,7 @@ class SlurmPipesClient(PipesClient):
                         )
 
                         # Cleanup
-                        if not self.debug_mode:
+                        if not self.debug_mode and not defer_cleanup:
                             try:
                                 self._schedule_async_cleanup(ssh_pool, run_dir)
                             except Exception as e:
@@ -464,7 +480,7 @@ class SlurmPipesClient(PipesClient):
                         )
 
                         # Cleanup
-                        if not self.debug_mode:
+                        if not self.debug_mode and not defer_cleanup:
                             try:
                                 self._schedule_async_cleanup(ssh_pool, run_dir)
                             except Exception as e:
@@ -697,7 +713,7 @@ class SlurmPipesClient(PipesClient):
                 )
 
                 # Cleanup (unless debug mode)
-                if not self.debug_mode:
+                if not self.debug_mode and not defer_cleanup:
                     try:
                         self._schedule_async_cleanup(ssh_pool, run_dir)
                     except Exception as e:
@@ -733,8 +749,16 @@ class SlurmPipesClient(PipesClient):
 
             self.logger.error(f"Execution failed: {e}")
 
-            # Cleanup on failure (unless debug mode)
-            if self.cleanup_on_failure and not self.debug_mode and run_dir:
+            # Cleanup on failure (unless debug mode, or the caller asked to
+            # defer cleanup because it may reuse this same run_dir -- for
+            # example a retry within a wave loop that reattaches to the same
+            # session/allocation).
+            if (
+                self.cleanup_on_failure
+                and not self.debug_mode
+                and not defer_cleanup
+                and run_dir
+            ):
                 try:
                     with ssh_pool:
                         self._schedule_async_cleanup(ssh_pool, run_dir)
@@ -768,6 +792,45 @@ class SlurmPipesClient(PipesClient):
             self._sigterm_received = False
 
         return PipesClientCompletedInvocation(session)
+
+    def cleanup_deferred_run_dir(self, *, context: AssetExecutionContext) -> None:
+        """Delete one step's ``run_dir`` after a run of ``defer_cleanup=True`` calls.
+
+        Call this once, after the caller is certain it will not invoke
+        ``run(..., defer_cleanup=True)`` again for the same Dagster
+        step/partition/mapping (see ``_get_remote_run_dir`` -- ``run_dir`` is
+        derived purely from ``remote_base``, the run id, and that identity, so
+        it is safe to recompute here without any state carried over from the
+        deferred calls). A natural place to call this is the same scope that
+        opted into reusing one session/allocation across repeated ``run()``
+        calls (for example, right before that scope releases its allocation
+        lease), once nothing else will write into this directory.
+
+        A no-op in debug mode, matching every other cleanup path on this
+        client (debug mode always preserves remote directories for
+        inspection).
+        """
+        if self.debug_mode:
+            return
+        if context.run:
+            run_id = context.run.run_id
+        else:
+            self.logger.warning(
+                "Context is not part of a Dagster run; skipping deferred run_dir "
+                "cleanup (no stable run_id to derive it from)."
+            )
+            return
+
+        ssh_pool = SSHConnectionPool(self.slurm.ssh)
+        try:
+            with ssh_pool:
+                remote_base = self._get_remote_base(run_id, ssh_pool)
+                run_dir = self._get_remote_run_dir(
+                    remote_base, run_id, context.op_execution_context
+                )
+                self._schedule_async_cleanup(ssh_pool, run_dir)
+        except Exception as exc:
+            self.logger.warning(f"Deferred run_dir cleanup failed: {exc}")
 
     @property
     def _control_path(self) -> Optional[str]:

--- a/projects/dagster-slurm/dagster_slurm/resources/compute.py
+++ b/projects/dagster-slurm/dagster_slurm/resources/compute.py
@@ -1434,3 +1434,25 @@ class ComputeResource(ConfigurableResource):
     def teardown_after_execution(self, context: InitResourceContext) -> None:
         """Release run-scoped allocations through Dagster's resource lifecycle."""
         self.teardown(context)
+
+    def cleanup_deferred_run_dir(self, context) -> None:
+        """Delete the remote ``run_dir`` for a step whose ``run()`` calls used
+        ``defer_cleanup=True``.
+
+        ``run(..., defer_cleanup=True)`` (see
+        ``SlurmPipesClient.run``/``SlurmPipesClient.cleanup_deferred_run_dir``)
+        exists for a caller that intentionally invokes ``run()`` repeatedly
+        for one Dagster step against the same session/allocation (for
+        example a per-wave loop) -- that pattern reuses the same
+        deterministic ``run_dir`` on every call, so per-call async cleanup
+        can race the next call's own upload into that directory. Callers
+        that opt into ``defer_cleanup`` must call this once they are truly
+        done calling ``run()`` for that step/partition, most naturally from
+        the same scope that decided to reuse one session/allocation across
+        calls (e.g. right before that scope releases its allocation lease).
+
+        A no-op outside Slurm execution modes (nothing was ever deferred).
+        """
+        client = self.get_pipes_client(context)
+        if isinstance(client, SlurmPipesClient):
+            client.cleanup_deferred_run_dir(context=context)

--- a/projects/dagster-slurm/dagster_slurm_test/test_defer_cleanup.py
+++ b/projects/dagster-slurm/dagster_slurm_test/test_defer_cleanup.py
@@ -1,0 +1,145 @@
+"""``defer_cleanup``/``cleanup_deferred_run_dir`` regression coverage.
+
+See issue #205: ``_schedule_async_cleanup`` fires a fire-and-forget
+``nohup rm -rf <run_dir> &`` after every ``run()`` call, including in
+session mode where a caller (e.g. a per-wave loop) intentionally invokes
+``run()`` repeatedly against the same deterministic ``run_dir``. The next
+call's ``mkdir -p``/upload into that same path can race the still-in-flight
+background deletion from the previous call. ``defer_cleanup=True`` lets such
+a caller skip that per-call cleanup and remove the directory itself, once,
+via ``cleanup_deferred_run_dir``.
+"""
+
+from pathlib import Path
+from typing import Any, cast
+
+from dagster_slurm import BashLauncher
+from dagster_slurm.pipes_clients.slurm_pipes_client import SlurmPipesClient
+
+from .test_env_caching import FakePool, configure_client_for_local_run, make_context
+
+
+def _make_client(pool: FakePool) -> SlurmPipesClient:
+    from types import SimpleNamespace
+
+    return SlurmPipesClient(
+        slurm_resource=cast(
+            Any,
+            SimpleNamespace(
+                ssh="dummy",
+                queue=SimpleNamespace(num_nodes=1),
+                remote_base="/remote/base",
+            ),
+        ),
+        launcher=BashLauncher(),
+    )
+
+
+def _rm_commands(pool: FakePool) -> list[str]:
+    return [cmd for cmd in pool.commands if "rm -rf" in cmd]
+
+
+def test_default_behavior_still_cleans_up_every_call(monkeypatch, tmp_path: Path):
+    """Regression guard: every existing caller (defer_cleanup unset) is unaffected."""
+    pool = FakePool()
+    client = _make_client(pool)
+    configure_client_for_local_run(client, monkeypatch, pool)
+
+    payload = tmp_path / "payload.py"
+    payload.write_text("print('hello')")
+
+    client.run(context=make_context(), payload_path=str(payload))
+
+    assert _rm_commands(pool), (
+        "run() without defer_cleanup must still trigger cleanup, exactly as "
+        "before this change"
+    )
+
+
+def test_defer_cleanup_skips_the_async_cleanup_this_call_would_trigger(
+    monkeypatch, tmp_path: Path
+):
+    pool = FakePool()
+    client = _make_client(pool)
+    configure_client_for_local_run(client, monkeypatch, pool)
+
+    payload = tmp_path / "payload.py"
+    payload.write_text("print('hello')")
+
+    client.run(context=make_context(), payload_path=str(payload), defer_cleanup=True)
+
+    assert not _rm_commands(pool), (
+        "defer_cleanup=True must suppress this call's own async cleanup so a "
+        "later call reusing the same run_dir cannot race an in-flight delete"
+    )
+
+
+def test_cleanup_deferred_run_dir_removes_the_same_run_dir_run_used(
+    monkeypatch, tmp_path: Path
+):
+    """The caller's later, explicit cleanup targets exactly the run_dir run() used.
+
+    ``run_dir`` is deterministic (remote_base + run_id + step/partition/
+    mapping identity), so ``cleanup_deferred_run_dir`` must recompute the
+    identical path without any state threaded through from the deferred
+    ``run()`` call.
+    """
+    pool = FakePool()
+    client = _make_client(pool)
+    configure_client_for_local_run(client, monkeypatch, pool)
+
+    payload = tmp_path / "payload.py"
+    payload.write_text("print('hello')")
+    context = make_context()
+
+    client.run(context=context, payload_path=str(payload), defer_cleanup=True)
+    assert not _rm_commands(pool)
+
+    client.cleanup_deferred_run_dir(context=context)
+
+    rm_commands = _rm_commands(pool)
+    assert len(rm_commands) == 1
+    assert "/remote/base/runs/run123/step" in rm_commands[0]
+
+
+def test_cleanup_deferred_run_dir_is_a_noop_in_debug_mode(monkeypatch, tmp_path: Path):
+    pool = FakePool()
+    client = _make_client(pool)
+    client.debug_mode = True
+    configure_client_for_local_run(client, monkeypatch, pool)
+
+    client.cleanup_deferred_run_dir(context=make_context())
+
+    assert not _rm_commands(pool)
+
+
+def test_defer_cleanup_also_suppresses_failure_path_cleanup(
+    monkeypatch, tmp_path: Path
+):
+    """A failed wave with defer_cleanup=True must not delete run_dir either.
+
+    The wave loop this exists for may retry (reusing the same run_dir) after
+    a failure, so per-call failure cleanup must defer exactly like success
+    cleanup does.
+    """
+    pool = FakePool()
+    client = _make_client(pool)
+    configure_client_for_local_run(client, monkeypatch, pool)
+    client.cleanup_on_failure = True
+
+    def _boom(**_kwargs):
+        raise RuntimeError("submission failed")
+
+    monkeypatch.setattr(client, "_execute_standalone", _boom)
+
+    payload = tmp_path / "payload.py"
+    payload.write_text("print('hello')")
+
+    try:
+        client.run(
+            context=make_context(), payload_path=str(payload), defer_cleanup=True
+        )
+    except RuntimeError:
+        pass
+
+    assert not _rm_commands(pool)


### PR DESCRIPTION
## Summary

Fixes #205.

`_schedule_async_cleanup` fires a fire-and-forget `nohup rm -rf <run_dir> >/dev/null 2>&1 &`
after every `SlurmPipesClient.run()` call — including in session mode, where a
caller intentionally invokes `run()` repeatedly for one Dagster step against
the same allocation/session (e.g. a per-wave adaptive-RapidOCR loop, or GPU-actor
retries within a wave). `run_dir` is deterministic per step/partition/mapping
(`_get_remote_run_dir`), not per call, so the *next* call's `mkdir -p`/upload
into that same path can genuinely race the still-in-flight background deletion
from the *previous* call — an unsynchronized delete-vs-recreate race on the
same remote directory, not merely wasted re-staging work.

- Live log evidence (run `bfbcba04-0615-474e-920a-b5f4461c5d62`,
  `patents_v3__document_with_rapidocr_heron[_tfv2]`) shows exactly this
  adjacency every wave: `Triggered asynchronous cleanup of remote directory:
  .../partition=normal` immediately followed by the next wave's `Creating
  remote run directory` / re-staging against the identical path.

## Change

- `SlurmPipesClient.run()`: new opt-in `defer_cleanup: bool = False` parameter.
  Default `False` — every existing caller (one `run()` call per directory) is
  unaffected. When `True`, skips the async cleanup this call would otherwise
  trigger on success, on a reattach outcome (still-running or already-completed
  job), and on failure (a failed wave may still be retried against the same
  `run_dir`).
- `SlurmPipesClient.cleanup_deferred_run_dir(context=...)`: recomputes the same
  deterministic `run_dir` and schedules its cleanup. For a caller that opted
  into `defer_cleanup=True`, call this once, after it is done calling `run()`
  repeatedly for that step (e.g. right before releasing the session/allocation
  lease it was reusing).
- `ComputeResource.cleanup_deferred_run_dir(context)`: thin convenience wrapper
  so callers that only see the `ComputeResource` facade (not the underlying
  `SlurmPipesClient`) don't need to reach into it.

This is the fix suggested in #205 ("don't schedule cleanup after every `run()`
call when session mode means the session — and therefore `run_dir` — is meant
to be reused"), implemented as an opt-in parameter rather than an unconditional
behavior change so no other caller's cleanup timing changes.

Downstream (jubust), this also eliminates the redundant per-wave re-staging
churn a separate investigation was tracking (same root cause: cleanup firing
once per `run()` call instead of once per step) — that fix is applied
independently on the consumer side (skips the wasted work), while this PR
fixes the underlying race (skips the *unsafe* timing) at its source.

## Test plan

- [x] New `dagster_slurm_test/test_defer_cleanup.py`: default behavior
      unchanged (cleanup still fires without `defer_cleanup`), `defer_cleanup=True`
      suppresses this call's cleanup (success and failure paths), and
      `cleanup_deferred_run_dir()` targets the exact same `run_dir` the deferred
      `run()` call used.
- [x] Full unit suite: `pixi run -e build pytest -m "not (needs_slurm_docker or slow)" projects` — 260 passed, 19 deselected, no regressions.
- [x] `pixi run -e build --frozen lint` (ruff + dprint + ty) — all clean.
- [x] `pixi run -e build --frozen fmt` — no changes needed beyond what was written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)