### PR TITLE
fix: session step reattach

### DIFF
--- a/docs/docs/how-to/execution-modes.md
+++ b/docs/docs/how-to/execution-modes.md
@@ -94,6 +94,8 @@ When Dagster restarts (deploy, code reload, crash), it sends `SIGTERM` to runnin
 
 With the **multiprocess executor**, the parent process unconditionally fails the run on `SIGTERM` (this is Dagster core behaviour). The Slurm job is preserved, and on re-launch `dagster-slurm` automatically discovers the existing job on the cluster — it **never resubmits**. Configure `run_retries` in `dagster.yaml` so the daemon re-launches failed runs automatically.
 
+Run-scoped Ray allocations use the same recovery model at the individual `srun` step level. Driver steps write durable step-ID, exit-status, and log markers before the local supervisor waits. A retry reattaches to the original allocation, replays its Pipes messages, and adopts a running or successfully completed step; only a known failed step is submitted again.
+
 See [Troubleshooting: Dagster restarts and Slurm job survival](./troubleshooting.md#dagster-restarts-and-slurm-job-survival) for details.
 
 :::

--- a/projects/dagster-slurm/dagster_slurm/pipes_clients/slurm_pipes_client.py
+++ b/projects/dagster-slurm/dagster_slurm/pipes_clients/slurm_pipes_client.py
@@ -58,10 +58,45 @@ from ..resources.slurm import SlurmResource, validate_signal_before_timeout
 _TAG_JOB_ID = "dagster_slurm/job_id"
 _TAG_RUN_DIR = "dagster_slurm/run_dir"
 _TAG_ASSET_KEY = "dagster_slurm/asset_key"
+_TAG_SESSION_ALLOCATION_DIR = "dagster_slurm/session_allocation_dir"
+_TAG_SESSION_STEP_ID = "dagster_slurm/session_step_id"
+_TAG_SESSION_STEP_ID_PATH = "dagster_slurm/session_step_id_path"
+_TAG_SESSION_STEP_STATUS_PATH = "dagster_slurm/session_step_status_path"
+_TAG_SESSION_STEP_STDOUT_PATH = "dagster_slurm/session_step_stdout_path"
+_TAG_SESSION_STEP_STDERR_PATH = "dagster_slurm/session_step_stderr_path"
+_TAG_SESSION_STEP_SCOPED_PREFIX = "dagster_slurm/session_step_"
 _TAG_LAST_SUPERVISOR_HEARTBEAT = "dagster_slurm/last_supervisor_heartbeat"
 _TAG_ORPHAN_RECONCILED_AT = "dagster_slurm/orphan_reconciled_at"
 _TAG_ORPHAN_RETRY_OF = "dagster_slurm/orphan_retry_of"
 _HEARTBEAT_INTERVAL_SECONDS = 30.0
+
+_SESSION_STEP_SCOPED_FIELDS = {
+    _TAG_JOB_ID: "j",
+    _TAG_RUN_DIR: "r",
+    _TAG_ASSET_KEY: "a",
+    _TAG_SESSION_ALLOCATION_DIR: "d",
+    _TAG_SESSION_STEP_ID: "i",
+    _TAG_SESSION_STEP_ID_PATH: "p",
+    _TAG_SESSION_STEP_STATUS_PATH: "s",
+    _TAG_SESSION_STEP_STDOUT_PATH: "o",
+    _TAG_SESSION_STEP_STDERR_PATH: "e",
+}
+
+
+def _session_step_scoped_tag_key(asset_key: str, field: str) -> str:
+    asset_digest = hashlib.sha256(asset_key.encode("utf-8")).hexdigest()[:16]
+    return f"{_TAG_SESSION_STEP_SCOPED_PREFIX}{asset_digest}_{field}"
+
+
+def _session_step_tags_for_asset(
+    tags: Mapping[str, str], asset_key: str
+) -> dict[str, str]:
+    scoped_tags: dict[str, str] = {}
+    for tag, field in _SESSION_STEP_SCOPED_FIELDS.items():
+        value = tags.get(_session_step_scoped_tag_key(asset_key, field))
+        if value:
+            scoped_tags[tag] = value
+    return scoped_tags
 
 
 class _TerminableProcess(Protocol):
@@ -342,6 +377,18 @@ class SlurmPipesClient(PipesClient):
                     op_ctx, ssh_pool, asset_key_str
                 )
                 if reattach_info:
+                    if use_session and reattach_info.get(_TAG_SESSION_STEP_STATUS_PATH):
+                        return self._reattach_session_step(
+                            context=context,
+                            ssh_pool=ssh_pool,
+                            reattach_info=reattach_info,
+                            extras=extras,
+                            poll_timeout=poll_timeout,
+                            enabled_slurm_metrics=enabled_slurm_metrics,
+                            metrics_collector=metrics_collector,
+                            defer_cleanup=defer_cleanup,
+                        )
+
                     old_job_id_str = reattach_info["job_id"]
                     old_run_dir = reattach_info["run_dir"]
                     old_job_id = int(old_job_id_str)
@@ -637,6 +684,7 @@ class SlurmPipesClient(PipesClient):
                             context=context,
                             run_dir=run_dir,
                             ssh_pool=ssh_pool,
+                            poll_timeout=poll_timeout,
                         )
                         job_id = step_result.job_id
                     else:
@@ -733,6 +781,12 @@ class SlurmPipesClient(PipesClient):
                 is_executor_interrupt
                 and not self._is_run_canceling(context.op_execution_context)
             ):
+                if use_session and self.session is not None:
+                    object.__setattr__(
+                        self.session,
+                        "_preserve_allocation_on_teardown",
+                        True,
+                    )
                 self.logger.warning(
                     f"Detaching due to {'SIGTERM' if self._sigterm_received else exc_name}. "
                     f"Slurm job {self._current_job_id} "
@@ -1087,6 +1141,43 @@ class SlurmPipesClient(PipesClient):
         except Exception as exc:
             self.logger.debug(f"Could not store reattach tags: {exc}")
 
+    def _store_session_step_tags(
+        self,
+        op_context: Optional[OpExecutionContext],
+        *,
+        result: SlurmStepExecutionResult,
+        run_dir: str,
+        asset_key: str | None,
+        allocation_dir: str,
+    ) -> None:
+        """Persist enough session-step identity for a retry to reattach."""
+        if op_context is None:
+            return
+
+        tags = {
+            _TAG_JOB_ID: str(result.job_id),
+            _TAG_RUN_DIR: run_dir,
+            _TAG_SESSION_ALLOCATION_DIR: allocation_dir,
+            _TAG_SESSION_STEP_ID: result.step_id or "",
+            _TAG_SESSION_STEP_ID_PATH: result.step_id_path or "",
+            _TAG_SESSION_STEP_STATUS_PATH: result.status_path or "",
+            _TAG_SESSION_STEP_STDOUT_PATH: result.stdout_path,
+            _TAG_SESSION_STEP_STDERR_PATH: result.stderr_path,
+        }
+        if asset_key:
+            tags[_TAG_ASSET_KEY] = asset_key
+            tags.update(
+                {
+                    _session_step_scoped_tag_key(asset_key, field): tags[tag]
+                    for tag, field in _SESSION_STEP_SCOPED_FIELDS.items()
+                    if tag in tags
+                }
+            )
+        try:
+            op_context.instance.add_run_tags(op_context.run_id, tags)
+        except Exception as exc:
+            self.logger.debug(f"Could not store session step tags: {exc}")
+
     def _store_supervisor_heartbeat(
         self,
         op_context: Optional[OpExecutionContext],
@@ -1138,18 +1229,34 @@ class SlurmPipesClient(PipesClient):
             if not isinstance(tags, Mapping):
                 return
 
+            if asset_key:
+                scoped_tags = _session_step_tags_for_asset(tags, asset_key)
+                if scoped_tags:
+                    tags = scoped_tags
+                elif tags.get(_TAG_ASSET_KEY) not in (None, asset_key):
+                    return
+
             job_id = tags.get(_TAG_JOB_ID)
             run_dir = tags.get(_TAG_RUN_DIR)
             if not job_id or not run_dir:
                 return
 
-            candidates.append(
-                {
-                    "job_id": job_id,
-                    "run_dir": run_dir,
-                    "allow_completed": allow_completed,
-                }
-            )
+            candidate = {
+                "job_id": job_id,
+                "run_dir": run_dir,
+                "allow_completed": allow_completed,
+            }
+            for tag in (
+                _TAG_SESSION_ALLOCATION_DIR,
+                _TAG_SESSION_STEP_ID,
+                _TAG_SESSION_STEP_ID_PATH,
+                _TAG_SESSION_STEP_STATUS_PATH,
+                _TAG_SESSION_STEP_STDOUT_PATH,
+                _TAG_SESSION_STEP_STDERR_PATH,
+            ):
+                if tags.get(tag):
+                    candidate[tag] = tags[tag]
+            candidates.append(candidate)
 
         # Strategy 0: orphan-reconcile sensor path. The sensor launches a new
         # run request carrying the original Slurm job tags directly.
@@ -1188,6 +1295,17 @@ class SlurmPipesClient(PipesClient):
         # An empty state means the job_id is completely unknown — skip it.
         for cand in candidates:
             try:
+                session_status_path = cand.get(_TAG_SESSION_STEP_STATUS_PATH)
+                if session_status_path:
+                    session_status = ssh_pool.run(
+                        f"cat {shlex.quote(str(session_status_path))} "
+                        "2>/dev/null || true"
+                    ).strip()
+                    if session_status.isdigit() and int(session_status) != 0:
+                        # A known failed step should be resubmitted inside the
+                        # recovered allocation, not adopted by the retry.
+                        continue
+
                 state = self._get_job_state(int(cand["job_id"]), ssh_pool)
                 if not state:
                     continue
@@ -1195,10 +1313,21 @@ class SlurmPipesClient(PipesClient):
                     # Fresh re-materializations must not adopt completed jobs from
                     # old failed runs. Only retry parent-run candidates may do that.
                     continue
-                return {
+                result = {
                     "job_id": str(cand["job_id"]),
                     "run_dir": str(cand.get("run_dir", "")),
                 }
+                for tag in (
+                    _TAG_SESSION_ALLOCATION_DIR,
+                    _TAG_SESSION_STEP_ID,
+                    _TAG_SESSION_STEP_ID_PATH,
+                    _TAG_SESSION_STEP_STATUS_PATH,
+                    _TAG_SESSION_STEP_STDOUT_PATH,
+                    _TAG_SESSION_STEP_STDERR_PATH,
+                ):
+                    if cand.get(tag):
+                        result[tag] = str(cand[tag])
+                return result
             except (ValueError, TypeError):
                 continue
 
@@ -2650,6 +2779,7 @@ rm -rf {pack_root_quoted}
         context: AssetExecutionContext,
         run_dir: str,
         ssh_pool: SSHConnectionPool,
+        poll_timeout: int,
     ) -> SlurmStepExecutionResult:
         """Execute in shared Slurm allocation with log streaming."""
         if not self.session:
@@ -2665,11 +2795,169 @@ rm -rf {pack_root_quoted}
             if len(selected_keys) > 1
             else str(next(iter(selected_keys)))
         )
+        allocation = self.session._allocation
+        if allocation is None:
+            raise RuntimeError("Session allocation is not initialized")
+
+        def store_step(result: SlurmStepExecutionResult) -> None:
+            self._store_session_step_tags(
+                context.op_execution_context,
+                result=result,
+                run_dir=run_dir,
+                asset_key=asset_key_str,
+                allocation_dir=allocation.working_dir,
+            )
+
+        def poll_step(result: SlurmStepExecutionResult) -> None:
+            self._poll_session_step(
+                result,
+                op_context=context.op_execution_context,
+                ssh_pool=ssh_pool,
+            )
+
         return self.session.execute_in_session(
             execution_plan=execution_plan,
             asset_key=asset_key_str,
             run_dir=run_dir,
+            step_update_callback=store_step,
+            poll_callback=poll_step,
+            timeout=poll_timeout,
         )
+
+    def _poll_session_step(
+        self,
+        result: SlurmStepExecutionResult,
+        *,
+        op_context: OpExecutionContext,
+        ssh_pool: SSHConnectionPool,
+    ) -> None:
+        self._store_supervisor_heartbeat(op_context)
+        if not self._is_run_canceling(op_context):
+            return
+
+        self._cancellation_requested = True
+        if result.step_id is not None:
+            ssh_pool.run(f"scancel {shlex.quote(result.step_id)}")
+        raise RuntimeError(f"Session step {result.step_id or '<starting>'} cancelled")
+
+    def _reattach_session_step(
+        self,
+        *,
+        context: AssetExecutionContext,
+        ssh_pool: SSHConnectionPool,
+        reattach_info: dict[str, str],
+        extras: dict[str, Any] | None,
+        poll_timeout: int,
+        enabled_slurm_metrics: SlurmMetricSelection,
+        metrics_collector: SlurmMetricsCallback | None,
+        defer_cleanup: bool,
+    ) -> PipesClientCompletedInvocation:
+        """Resume a durable srun step inside an existing session allocation."""
+        if not self.session or not self.session._allocation:
+            raise RuntimeError("Session step reattachment requires an allocation")
+        allocation = self.session._allocation
+
+        required_tags = (
+            _TAG_SESSION_STEP_ID_PATH,
+            _TAG_SESSION_STEP_STATUS_PATH,
+            _TAG_SESSION_STEP_STDOUT_PATH,
+            _TAG_SESSION_STEP_STDERR_PATH,
+        )
+        missing = [tag for tag in required_tags if not reattach_info.get(tag)]
+        if missing:
+            raise RuntimeError(
+                "Session step reattachment metadata is incomplete: "
+                + ", ".join(missing)
+            )
+
+        allocation_job_id = int(reattach_info["job_id"])
+        if allocation.slurm_job_id != allocation_job_id:
+            raise RuntimeError(
+                "Session retry attached to allocation "
+                f"{allocation.slurm_job_id}, expected {allocation_job_id}"
+            )
+
+        step_result = SlurmStepExecutionResult(
+            job_id=allocation_job_id,
+            stdout_path=reattach_info[_TAG_SESSION_STEP_STDOUT_PATH],
+            stderr_path=reattach_info[_TAG_SESSION_STEP_STDERR_PATH],
+            step_id=reattach_info.get(_TAG_SESSION_STEP_ID),
+            step_id_path=reattach_info[_TAG_SESSION_STEP_ID_PATH],
+            status_path=reattach_info[_TAG_SESSION_STEP_STATUS_PATH],
+        )
+        run_dir = reattach_info["run_dir"]
+        op_context = context.op_execution_context
+        message_reader = SSHMessageReader(
+            remote_path=f"{run_dir}/messages.jsonl",
+            ssh_config=self.slurm.ssh,
+            control_path=ssh_pool.control_path,
+            ssh_pool=ssh_pool,
+        )
+        self.logger.info(
+            "Reattaching to session step %s in allocation %s",
+            step_result.step_id or step_result.step_id_path,
+            allocation_job_id,
+        )
+
+        def store_step(result: SlurmStepExecutionResult) -> None:
+            self._store_session_step_tags(
+                op_context,
+                result=result,
+                run_dir=run_dir,
+                asset_key=self._get_asset_key_string(op_context),
+                allocation_dir=allocation.working_dir,
+            )
+
+        def poll_step(result: SlurmStepExecutionResult) -> None:
+            self._poll_session_step(
+                result,
+                op_context=op_context,
+                ssh_pool=ssh_pool,
+            )
+
+        with open_pipes_session(
+            context=op_context,
+            context_injector=PipesEnvContextInjector(),
+            message_reader=message_reader,
+            extras=extras,
+        ) as session:
+            step_result = allocation.wait_for_step(
+                step_result,
+                ssh_pool=ssh_pool,
+                step_update_callback=store_step,
+                poll_callback=poll_step,
+                timeout=poll_timeout,
+            )
+            self._maybe_emit_final_logs(
+                message_reader=message_reader,
+                ssh_pool=ssh_pool,
+                run_dir=run_dir,
+                job_id=allocation_job_id,
+                op_context=op_context,
+                stdout_path=step_result.stdout_path,
+                stderr_path=step_result.stderr_path,
+            )
+            self._emit_session_metadata(step_result, context)
+            step_metrics = self._collect_session_step_metrics(
+                step_result=step_result,
+                ssh_pool=ssh_pool,
+            )
+            self._collect_and_emit_metrics(
+                allocation_job_id,
+                ssh_pool,
+                context,
+                metrics=step_metrics,
+                slurm_metrics=enabled_slurm_metrics,
+                custom_metrics_collector=metrics_collector,
+            )
+
+        self._raise_if_pipes_process_failed(
+            message_reader,
+            job_id=allocation_job_id,
+        )
+        if not self.debug_mode and not defer_cleanup:
+            self._schedule_async_cleanup(ssh_pool, run_dir)
+        return PipesClientCompletedInvocation(session)
 
     def _resolve_signal_before_timeout(
         self,

--- a/projects/dagster-slurm/dagster_slurm/resources/session.py
+++ b/projects/dagster-slurm/dagster_slurm/resources/session.py
@@ -8,9 +8,9 @@ import shlex
 import re
 import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace as dataclass_replace
 from enum import Enum
-from typing import Any, List, Literal, Optional, Set
+from typing import Any, Callable, List, Literal, Optional, Set
 import uuid
 
 from dagster import (
@@ -41,6 +41,7 @@ _REMOTE_LOCK_WAIT_TIMEOUT_SECONDS = 180
 _REMOTE_LOCK_POLL_SECONDS = 2
 _SHARED_ALLOCATION_CLEANUP_GRACE_SECONDS = 10
 _SAFE_AUXILIARY_SCRIPT_NAME_RE = re.compile(r"^[A-Za-z0-9_.=-]+$")
+_SESSION_ALLOCATION_DIR_TAG = "dagster_slurm/session_allocation_dir"
 
 
 def _validate_nodelist(nodelist: str | None) -> None:
@@ -241,6 +242,8 @@ class SlurmStepExecutionResult:
     stdout_path: str
     stderr_path: str
     step_id: str | None = None
+    step_id_path: str | None = None
+    status_path: str | None = None
 
 
 class SlurmSessionResource(ConfigurableResource):
@@ -333,6 +336,7 @@ class SlurmSessionResource(ConfigurableResource):
     _context: Any = PrivateAttr(default=None)
     _owns_allocation: bool = PrivateAttr(default=False)
     _shared_lifecycle: bool = PrivateAttr(default=False)
+    _preserve_allocation_on_teardown: bool = PrivateAttr(default=False)
     _allocation_lease_id: Optional[str] = PrivateAttr(default=None)
 
     @property
@@ -385,7 +389,12 @@ class SlurmSessionResource(ConfigurableResource):
             # Cancel allocation
             if self._allocation:
                 try:
-                    if self._shared_lifecycle:
+                    if self._preserve_allocation_on_teardown:
+                        self.logger.info(
+                            "Preserving allocation %s for supervisor reattachment",
+                            self._allocation.slurm_job_id,
+                        )
+                    elif self._shared_lifecycle:
                         self._schedule_shared_allocation_cleanup()
                     elif self._owns_allocation:
                         self._allocation.cancel(self._ssh_pool)  # type: ignore
@@ -415,6 +424,9 @@ class SlurmSessionResource(ConfigurableResource):
         execution_plan: ExecutionPlan,
         asset_key: str,
         run_dir: str,
+        step_update_callback: Callable[[SlurmStepExecutionResult], None] | None = None,
+        poll_callback: Callable[[SlurmStepExecutionResult], None] | None = None,
+        timeout: int | None = None,
     ) -> SlurmStepExecutionResult:
         """Execute workload in the shared allocation.
         Thread-safe for parallel asset execution.
@@ -444,6 +456,9 @@ class SlurmSessionResource(ConfigurableResource):
                 asset_key=asset_key,
                 run_dir=run_dir,
                 ssh_pool=self._ssh_pool,  # type: ignore
+                step_update_callback=step_update_callback,
+                poll_callback=poll_callback,
+                timeout=timeout,
             )
 
     def _resolve_run_id(self, context) -> str:
@@ -465,7 +480,23 @@ class SlurmSessionResource(ConfigurableResource):
     def _create_allocation(self, context) -> "SlurmAllocation":
         """Start or attach to the run's Slurm allocation."""
         allocation_id = f"dagster_{self._resolve_run_id(context)}"
-        working_dir = f"{self.slurm.remote_base}/allocations/{allocation_id}"
+        allocations_root = posixpath.normpath(f"{self.slurm.remote_base}/allocations")
+        working_dir = f"{allocations_root}/{allocation_id}"
+        if context.run:
+            tagged_dir = getattr(context.run, "tags", {}).get(
+                _SESSION_ALLOCATION_DIR_TAG
+            )
+            if tagged_dir:
+                normalized_tagged_dir = posixpath.normpath(tagged_dir)
+                if normalized_tagged_dir.startswith(f"{allocations_root}/"):
+                    working_dir = normalized_tagged_dir
+                    allocation_id = posixpath.basename(working_dir)
+                else:
+                    self.logger.warning(
+                        "Ignoring session allocation directory outside %s: %s",
+                        allocations_root,
+                        tagged_dir,
+                    )
 
         ssh_pool = self._require_ssh_pool()
         ssh_pool.run(f"mkdir -p {shlex.quote(working_dir)}")
@@ -852,6 +883,9 @@ class SlurmAllocation:
         asset_key: str,
         run_dir: str,
         ssh_pool: SSHConnectionPool,
+        step_update_callback: Callable[[SlurmStepExecutionResult], None] | None = None,
+        poll_callback: Callable[[SlurmStepExecutionResult], None] | None = None,
+        timeout: int | None = None,
     ) -> SlurmStepExecutionResult:
         """Execute plan in this allocation via srun."""
         with self._exec_lock:
@@ -888,48 +922,117 @@ class SlurmAllocation:
         log_name = f"slurm-{self.slurm_job_id}-step-{exec_id}_{safe_asset_key}"
         stdout_path = f"{run_dir}/{log_name}.out"
         stderr_path = f"{run_dir}/{log_name}.err"
+        status_path = f"{run_dir}/.slurm-step-{exec_id}.status"
 
-        # Execute via srun
+        # Launch the step from a detached remote wrapper. The wrapper and its
+        # status marker survive a local Dagster supervisor restart, allowing a
+        # retry to reattach to this exact invocation instead of resubmitting it.
         srun_cmd = (
             f"srun --overlap --jobid={self.slurm_job_id} "
             f"--job-name=asset_{exec_id} {shlex.quote(script_path)} "
             f"> {shlex.quote(stdout_path)} 2> {shlex.quote(stderr_path)}"
         )
-
-        self.logger.info(f"Executing in allocation {self.slurm_job_id}: {script_name}")
-        try:
-            ssh_pool.run(srun_cmd)
-        except Exception as exc:
-            stdout_tail = _tail_remote_file_for_error(ssh_pool, stdout_path)
-            stderr_tail = _tail_remote_file_for_error(ssh_pool, stderr_path)
-            raise RuntimeError(
-                f"srun step {exec_id} failed in allocation {self.slurm_job_id}. "
-                f"stdout_path={stdout_path}; stderr_path={stderr_path}\n"
-                f"Original error: {exc}\n"
-                f"--- stdout tail ---\n{stdout_tail}\n"
-                f"--- stderr tail ---\n{stderr_tail}"
-            ) from exc
-        self.logger.info(
-            f"Execution {exec_id} in allocation {self.slurm_job_id} completed"
+        status_tmp_path = f"{status_path}.tmp"
+        wrapper = (
+            "set +e\n"
+            f"{srun_cmd}\n"
+            "status=$?\n"
+            f"printf '%s\\n' \"$status\" > {shlex.quote(status_tmp_path)}\n"
+            f"mv {shlex.quote(status_tmp_path)} {shlex.quote(status_path)}"
+        )
+        launch_cmd = (
+            f"rm -f {shlex.quote(step_id_path)} {shlex.quote(status_path)} "
+            f"{shlex.quote(status_tmp_path)}; "
+            "nohup bash --noprofile --norc -c "
+            f"{shlex.quote(wrapper)} </dev/null >/dev/null 2>&1 &"
         )
 
-        step_id = ssh_pool.run(
-            f"cat {shlex.quote(step_id_path)} 2>/dev/null || true"
-        ).strip()
-        if not re.fullmatch(rf"{self.slurm_job_id}\.[A-Za-z0-9_+-]+", step_id):
-            self.logger.warning(
-                "Could not determine Slurm step ID for execution %s in allocation %s",
-                exec_id,
-                self.slurm_job_id,
-            )
-            step_id = None
-
-        return SlurmStepExecutionResult(
+        self.logger.info(f"Executing in allocation {self.slurm_job_id}: {script_name}")
+        ssh_pool.run(launch_cmd)
+        result = SlurmStepExecutionResult(
             job_id=self.slurm_job_id,
             stdout_path=stdout_path,
             stderr_path=stderr_path,
-            step_id=step_id,
+            step_id_path=step_id_path,
+            status_path=status_path,
         )
+        if step_update_callback is not None:
+            step_update_callback(result)
+
+        return self.wait_for_step(
+            result,
+            ssh_pool=ssh_pool,
+            step_update_callback=step_update_callback,
+            poll_callback=poll_callback,
+            timeout=timeout,
+        )
+
+    def wait_for_step(
+        self,
+        result: SlurmStepExecutionResult,
+        *,
+        ssh_pool: SSHConnectionPool,
+        step_update_callback: Callable[[SlurmStepExecutionResult], None] | None = None,
+        poll_callback: Callable[[SlurmStepExecutionResult], None] | None = None,
+        timeout: int | None = None,
+    ) -> SlurmStepExecutionResult:
+        """Wait for a launched allocation step, including after supervisor restart."""
+        if result.step_id_path is None or result.status_path is None:
+            raise ValueError("Session step reattachment requires id and status paths")
+
+        started_at = time.monotonic()
+        current = result
+        while True:
+            step_id = ssh_pool.run(
+                f"cat {shlex.quote(result.step_id_path)} 2>/dev/null || true"
+            ).strip()
+            if current.step_id is None and re.fullmatch(
+                rf"{result.job_id}\.[A-Za-z0-9_+-]+",
+                step_id,
+            ):
+                current = dataclass_replace(current, step_id=step_id)
+                if step_update_callback is not None:
+                    step_update_callback(current)
+
+            status = ssh_pool.run(
+                f"cat {shlex.quote(result.status_path)} 2>/dev/null || true"
+            ).strip()
+            if status:
+                if not re.fullmatch(r"\d+", status):
+                    raise RuntimeError(
+                        f"Invalid session step status {status!r} at {result.status_path}"
+                    )
+                return_code = int(status)
+                if return_code != 0:
+                    stdout_tail = _tail_remote_file_for_error(
+                        ssh_pool, result.stdout_path
+                    )
+                    stderr_tail = _tail_remote_file_for_error(
+                        ssh_pool, result.stderr_path
+                    )
+                    raise RuntimeError(
+                        f"srun step failed in allocation {result.job_id} "
+                        f"with exit code {return_code}. "
+                        f"stdout_path={result.stdout_path}; "
+                        f"stderr_path={result.stderr_path}\n"
+                        f"--- stdout tail ---\n{stdout_tail}\n"
+                        f"--- stderr tail ---\n{stderr_tail}"
+                    )
+                self.logger.info(
+                    "Execution %s in allocation %s completed",
+                    current.step_id or "<pending-step-id>",
+                    result.job_id,
+                )
+                return current
+
+            if poll_callback is not None:
+                poll_callback(current)
+            if timeout is not None and time.monotonic() - started_at > timeout:
+                raise TimeoutError(
+                    f"Timed out after {timeout}s waiting for allocation step "
+                    f"in job {result.job_id}"
+                )
+            time.sleep(1)
 
     def ensure_ray_cluster(
         self,

--- a/projects/dagster-slurm/dagster_slurm/sensors.py
+++ b/projects/dagster-slurm/dagster_slurm/sensors.py
@@ -17,6 +17,13 @@ from dagster_slurm.pipes_clients.slurm_pipes_client import (
     _TAG_ORPHAN_RECONCILED_AT,
     _TAG_ORPHAN_RETRY_OF,
     _TAG_RUN_DIR,
+    _TAG_SESSION_ALLOCATION_DIR,
+    _TAG_SESSION_STEP_ID,
+    _TAG_SESSION_STEP_ID_PATH,
+    _TAG_SESSION_STEP_SCOPED_PREFIX,
+    _TAG_SESSION_STEP_STATUS_PATH,
+    _TAG_SESSION_STEP_STDERR_PATH,
+    _TAG_SESSION_STEP_STDOUT_PATH,
 )
 from dagster_slurm.resources.slurm import SlurmResource
 
@@ -100,6 +107,24 @@ def _build_reattach_run_request(
     asset_key = run.tags.get(_TAG_ASSET_KEY)
     if asset_key:
         tags[_TAG_ASSET_KEY] = asset_key
+
+    for tag in (
+        _TAG_SESSION_ALLOCATION_DIR,
+        _TAG_SESSION_STEP_ID,
+        _TAG_SESSION_STEP_ID_PATH,
+        _TAG_SESSION_STEP_STATUS_PATH,
+        _TAG_SESSION_STEP_STDOUT_PATH,
+        _TAG_SESSION_STEP_STDERR_PATH,
+    ):
+        if run.tags.get(tag):
+            tags[tag] = run.tags[tag]
+    tags.update(
+        {
+            tag: value
+            for tag, value in run.tags.items()
+            if tag.startswith(_TAG_SESSION_STEP_SCOPED_PREFIX)
+        }
+    )
 
     partition_key = run.tags.get(PARTITION_NAME_TAG)
     if partition_key:

--- a/projects/dagster-slurm/dagster_slurm_test/test_cancellation.py
+++ b/projects/dagster-slurm/dagster_slurm_test/test_cancellation.py
@@ -24,7 +24,15 @@ from dagster_slurm.pipes_clients.slurm_pipes_client import (
     _TAG_ASSET_KEY,
     _TAG_JOB_ID,
     _TAG_RUN_DIR,
+    _TAG_SESSION_ALLOCATION_DIR,
+    _TAG_SESSION_STEP_ID,
+    _TAG_SESSION_STEP_ID_PATH,
+    _TAG_SESSION_STEP_STATUS_PATH,
+    _TAG_SESSION_STEP_STDERR_PATH,
+    _TAG_SESSION_STEP_STDOUT_PATH,
+    _session_step_scoped_tag_key,
 )
+from dagster_slurm.resources.session import SlurmStepExecutionResult
 
 
 def _make_client() -> SlurmPipesClient:
@@ -313,6 +321,40 @@ def test_store_job_tags_none_context():
     client._store_job_tags(None, 42, "/tmp/run_dir", "my_asset")
 
 
+def test_store_session_step_tags_records_durable_invocation():
+    client = _make_client()
+    mock_op_context = MagicMock()
+    mock_op_context.run_id = "test-run-id"
+    result = SlurmStepExecutionResult(
+        job_id=42,
+        stdout_path="/tmp/run/stdout",
+        stderr_path="/tmp/run/stderr",
+        step_id="42.7",
+        step_id_path="/tmp/run/.step.id",
+        status_path="/tmp/run/.step.status",
+    )
+
+    client._store_session_step_tags(
+        mock_op_context,
+        result=result,
+        run_dir="/tmp/run",
+        asset_key="my_asset",
+        allocation_dir="/tmp/allocations/dagster_original",
+    )
+
+    stored_tags = mock_op_context.instance.add_run_tags.call_args.args[1]
+    assert stored_tags[_TAG_JOB_ID] == "42"
+    assert stored_tags[_TAG_RUN_DIR] == "/tmp/run"
+    assert stored_tags[_TAG_SESSION_ALLOCATION_DIR].endswith("dagster_original")
+    assert stored_tags[_TAG_SESSION_STEP_ID] == "42.7"
+    assert stored_tags[_TAG_SESSION_STEP_ID_PATH].endswith(".step.id")
+    assert stored_tags[_TAG_SESSION_STEP_STATUS_PATH].endswith(".step.status")
+    assert stored_tags[_TAG_SESSION_STEP_STDOUT_PATH].endswith("stdout")
+    assert stored_tags[_TAG_SESSION_STEP_STDERR_PATH].endswith("stderr")
+    assert stored_tags[_TAG_ASSET_KEY] == "my_asset"
+    assert stored_tags[_session_step_scoped_tag_key("my_asset", "i")] == "42.7"
+
+
 def test_get_asset_key_string_single_asset():
     """_get_asset_key_string returns the asset key as a string."""
     client = _make_client()
@@ -356,6 +398,104 @@ def test_find_reattachable_job_from_parent_run():
     assert result is not None
     assert result["job_id"] == "42"
     assert result["run_dir"] == "/tmp/old_run_dir"
+
+
+def test_find_reattachable_job_preserves_session_step_metadata():
+    client = _make_client()
+    mock_op_context = MagicMock()
+    mock_op_context.dagster_run.parent_run_id = "parent-run-123"
+    parent_run = MagicMock()
+    parent_run.tags = {
+        _TAG_JOB_ID: "42",
+        _TAG_RUN_DIR: "/tmp/old_run_dir",
+        _TAG_SESSION_ALLOCATION_DIR: "/tmp/allocations/dagster_original",
+        _TAG_SESSION_STEP_ID: "42.7",
+        _TAG_SESSION_STEP_ID_PATH: "/tmp/old_run_dir/.step.id",
+        _TAG_SESSION_STEP_STATUS_PATH: "/tmp/old_run_dir/.step.status",
+        _TAG_SESSION_STEP_STDOUT_PATH: "/tmp/old_run_dir/stdout",
+        _TAG_SESSION_STEP_STDERR_PATH: "/tmp/old_run_dir/stderr",
+    }
+    mock_op_context.instance.get_run_by_id.return_value = parent_run
+    ssh_pool = MagicMock()
+    ssh_pool.run.return_value = ""
+
+    with patch.object(client, "_get_job_state", return_value="RUNNING"):
+        result = client._find_reattachable_job(
+            mock_op_context,
+            ssh_pool,
+            "my_asset",
+        )
+
+    assert result is not None
+    assert result[_TAG_SESSION_STEP_ID] == "42.7"
+    assert result[_TAG_SESSION_STEP_STATUS_PATH].endswith(".step.status")
+
+
+def test_find_reattachable_job_selects_parallel_asset_step_metadata():
+    client = _make_client()
+    mock_op_context = MagicMock()
+    mock_op_context.dagster_run.parent_run_id = "parent-run-123"
+    parent_tags = {
+        _TAG_JOB_ID: "42",
+        _TAG_RUN_DIR: "/tmp/asset-b",
+        _TAG_ASSET_KEY: "asset-b",
+    }
+    for asset_key, step_id in (("asset-a", "42.7"), ("asset-b", "42.8")):
+        scoped_values = {
+            "j": "42",
+            "r": f"/tmp/{asset_key}",
+            "a": asset_key,
+            "d": "/tmp/allocations/dagster_original",
+            "i": step_id,
+            "p": f"/tmp/{asset_key}/.step.id",
+            "s": f"/tmp/{asset_key}/.step.status",
+            "o": f"/tmp/{asset_key}/stdout",
+            "e": f"/tmp/{asset_key}/stderr",
+        }
+        parent_tags.update(
+            {
+                _session_step_scoped_tag_key(asset_key, field): value
+                for field, value in scoped_values.items()
+            }
+        )
+    parent_run = MagicMock(tags=parent_tags)
+    mock_op_context.instance.get_run_by_id.return_value = parent_run
+    ssh_pool = MagicMock()
+    ssh_pool.run.return_value = ""
+
+    with patch.object(client, "_get_job_state", return_value="RUNNING"):
+        result = client._find_reattachable_job(
+            mock_op_context,
+            ssh_pool,
+            "asset-a",
+        )
+
+    assert result is not None
+    assert result[_TAG_SESSION_STEP_ID] == "42.7"
+    assert result["run_dir"] == "/tmp/asset-a"
+
+
+def test_find_reattachable_job_skips_failed_session_step():
+    client = _make_client()
+    mock_op_context = MagicMock()
+    mock_op_context.dagster_run.parent_run_id = "parent-run-123"
+    parent_run = MagicMock()
+    parent_run.tags = {
+        _TAG_JOB_ID: "42",
+        _TAG_RUN_DIR: "/tmp/old_run_dir",
+        _TAG_SESSION_STEP_STATUS_PATH: "/tmp/old_run_dir/.step.status",
+    }
+    mock_op_context.instance.get_run_by_id.return_value = parent_run
+    ssh_pool = MagicMock()
+    ssh_pool.run.return_value = "1"
+
+    result = client._find_reattachable_job(
+        mock_op_context,
+        ssh_pool,
+        "my_asset",
+    )
+
+    assert result is None
 
 
 def test_find_reattachable_job_from_failed_run_query():

--- a/projects/dagster-slurm/dagster_slurm_test/test_orphan_reconcile.py
+++ b/projects/dagster-slurm/dagster_slurm_test/test_orphan_reconcile.py
@@ -11,7 +11,10 @@ from dagster_slurm.pipes_clients.slurm_pipes_client import (
     _TAG_LAST_SUPERVISOR_HEARTBEAT,
     _TAG_ORPHAN_RETRY_OF,
     _TAG_RUN_DIR,
+    _TAG_SESSION_ALLOCATION_DIR,
+    _TAG_SESSION_STEP_STATUS_PATH,
     SlurmPipesClient,
+    _session_step_scoped_tag_key,
 )
 from dagster_slurm.sensors import reconcile_orphaned_slurm_runs
 
@@ -80,6 +83,16 @@ def _add_started_run(
 def test_reconcile_terminal_orphan_marks_failed_and_requests_reattach():
     with dg.DagsterInstance.ephemeral() as instance:
         run = _add_started_run(instance)
+        instance.add_run_tags(
+            run.run_id,
+            {
+                _TAG_SESSION_ALLOCATION_DIR: "/remote/allocations/dagster_original",
+                _TAG_SESSION_STEP_STATUS_PATH: "/remote/run-dir/.step.status",
+                _session_step_scoped_tag_key("orphan_asset", "s"): (
+                    "/remote/run-dir/.step.status"
+                ),
+            },
+        )
 
         with patch(
             "dagster_slurm.sensors.SSHConnectionPool",
@@ -100,6 +113,14 @@ def test_reconcile_terminal_orphan_marks_failed_and_requests_reattach():
         assert request.asset_selection == [dg.AssetKey("orphan_asset")]
         assert request.tags[_TAG_JOB_ID] == "42"
         assert request.tags[_TAG_RUN_DIR] == "/remote/run-dir"
+        assert (
+            request.tags[_TAG_SESSION_ALLOCATION_DIR]
+            == "/remote/allocations/dagster_original"
+        )
+        assert request.tags[_TAG_SESSION_STEP_STATUS_PATH].endswith(".step.status")
+        assert request.tags[_session_step_scoped_tag_key("orphan_asset", "s")].endswith(
+            ".step.status"
+        )
         assert request.tags[_TAG_ORPHAN_RETRY_OF] == run.run_id
 
 

--- a/projects/dagster-slurm/dagster_slurm_test/test_resources.py
+++ b/projects/dagster-slurm/dagster_slurm_test/test_resources.py
@@ -34,6 +34,7 @@ from dagster_slurm.pipes_clients.slurm_pipes_client import SlurmPipesClient
 from dagster_slurm.resources.session import (
     SlurmAllocation,
     SlurmSessionResource,
+    SlurmStepExecutionResult,
     _try_acquire_remote_lock,
 )
 
@@ -348,6 +349,8 @@ def test_slurm_allocation_execute_uses_per_step_log_paths():
                 return "42.7"
             if ".slurm-step-2.id" in cmd:
                 return "42.8"
+            if ".slurm-step-" in cmd and ".status" in cmd:
+                return "0"
             return ""
 
     session = SlurmSessionResource(slurm=_mock_slurm_resource())
@@ -365,12 +368,14 @@ def test_slurm_allocation_execute_uses_per_step_log_paths():
     )
     fake_ssh_pool = FakeSSHPool()
     ssh_pool = cast(SSHConnectionPool, fake_ssh_pool)
+    updates: list[SlurmStepExecutionResult] = []
 
     first = allocation.execute(
         plan,
         asset_key="asset/one",
         run_dir="/remote/run/one",
         ssh_pool=ssh_pool,
+        step_update_callback=updates.append,
     )
     second = allocation.execute(
         plan,
@@ -384,10 +389,12 @@ def test_slurm_allocation_execute_uses_per_step_log_paths():
     assert first.stderr_path != second.stderr_path
     assert first.stdout_path.endswith("slurm-42-step-1_asset_one.out")
     assert second.stdout_path.endswith("slurm-42-step-2_asset_two.out")
-    assert first.stdout_path in fake_ssh_pool.commands[1]
-    assert second.stdout_path in fake_ssh_pool.commands[4]
+    assert any(first.stdout_path in command for command in fake_ssh_pool.commands)
+    assert any(second.stdout_path in command for command in fake_ssh_pool.commands)
     assert first.step_id == "42.7"
     assert second.step_id == "42.8"
+    assert [update.step_id for update in updates] == [None, "42.7"]
+    assert updates[0].status_path == "/remote/run/one/.slurm-step-1.status"
 
 
 def test_slurm_session_allocation_honors_zero_gpu_override(monkeypatch):
@@ -918,6 +925,8 @@ def test_slurm_allocation_accepts_safe_auxiliary_script_names():
             self.commands.append(cmd)
             if cmd.startswith("cat /remote/run/.slurm-step-1.id"):
                 return "42.7"
+            if cmd.startswith("cat /remote/run/.slurm-step-1.status"):
+                return "0"
             return ""
 
     allocation = SlurmAllocation(
@@ -951,8 +960,10 @@ def test_slurm_allocation_accepts_safe_auxiliary_script_names():
         "/remote/run/ray_driver.sh",
         "/remote/run/ray_worker-1.sh",
     ]
-    assert fake_ssh_pool.commands[-2].startswith(
-        "srun --overlap --jobid=42 --job-name=asset_1"
+    assert any(
+        "srun --overlap --jobid=42 --job-name=asset_1" in command
+        and "nohup bash" in command
+        for command in fake_ssh_pool.commands
     )
     asset_script = fake_ssh_pool.writes[0][1].splitlines()
     assert asset_script[0] == "#!/bin/bash"
@@ -971,8 +982,10 @@ def test_slurm_allocation_srun_failure_reports_step_logs():
 
         def run(self, cmd: str):
             self.commands.append(cmd)
-            if cmd.startswith("srun --overlap"):
-                raise RuntimeError("ssh command failed")
+            if cmd.startswith("cat /remote/run/.slurm-step-1.id"):
+                return "42.7"
+            if cmd.startswith("cat /remote/run/.slurm-step-1.status"):
+                return "1"
             if "slurm-42-step-1_asset.out" in cmd:
                 return "captured stdout"
             if "slurm-42-step-1_asset.err" in cmd:
@@ -1002,11 +1015,52 @@ def test_slurm_allocation_srun_failure_reports_step_logs():
         )
 
     message = str(exc_info.value)
-    assert "srun step 1 failed in allocation 42" in message
+    assert "srun step failed in allocation 42" in message
     assert "stdout_path=/remote/run/slurm-42-step-1_asset.out" in message
     assert "stderr_path=/remote/run/slurm-42-step-1_asset.err" in message
     assert "captured stdout" in message
     assert "captured stderr" in message
+
+
+def test_slurm_allocation_wait_for_step_reattaches_to_existing_markers(monkeypatch):
+    class FakeSSHPool:
+        status_reads = 0
+
+        def run(self, cmd: str) -> str:
+            if cmd.startswith("cat /remote/run/.step.id"):
+                return "42.7"
+            if cmd.startswith("cat /remote/run/.step.status"):
+                self.status_reads += 1
+                return "0" if self.status_reads > 1 else ""
+            return ""
+
+    allocation = SlurmAllocation(
+        slurm_job_id=42,
+        nodes=["c1"],
+        working_dir="/remote/session",
+        config=SlurmSessionResource(slurm=_mock_slurm_resource()),
+    )
+    updates: list[SlurmStepExecutionResult] = []
+    polls: list[str | None] = []
+    monkeypatch.setattr(time, "sleep", lambda _seconds: None)
+
+    result = allocation.wait_for_step(
+        SlurmStepExecutionResult(
+            job_id=42,
+            stdout_path="/remote/run/stdout",
+            stderr_path="/remote/run/stderr",
+            step_id_path="/remote/run/.step.id",
+            status_path="/remote/run/.step.status",
+        ),
+        ssh_pool=cast(SSHConnectionPool, FakeSSHPool()),
+        step_update_callback=updates.append,
+        poll_callback=lambda current: polls.append(current.step_id),
+        timeout=10,
+    )
+
+    assert result.step_id == "42.7"
+    assert [update.step_id for update in updates] == ["42.7"]
+    assert polls == ["42.7"]
 
 
 def test_persistent_ray_scripts_use_node_local_temp_dirs_and_hostname_address():
@@ -1070,6 +1124,27 @@ def test_run_allocation_session_creation_is_thread_safe(monkeypatch):
 
     assert len(set(session_ids)) == 1
     assert len(setup_calls) == 1
+
+
+def test_session_teardown_preserves_allocation_for_reattach(monkeypatch):
+    session = SlurmSessionResource(slurm=_mock_slurm_resource())
+    allocation = SimpleNamespace(slurm_job_id=42, cancel=lambda _pool: None)
+    ssh_pool = SimpleNamespace(__exit__=lambda *_args: None)
+    cleanup_calls: list[int] = []
+    monkeypatch.setattr(
+        session,
+        "_schedule_shared_allocation_cleanup",
+        lambda: cleanup_calls.append(42),
+    )
+    object.__setattr__(session, "_allocation", allocation)
+    object.__setattr__(session, "_ssh_pool", ssh_pool)
+    object.__setattr__(session, "_initialized", True)
+    object.__setattr__(session, "_shared_lifecycle", True)
+    object.__setattr__(session, "_preserve_allocation_on_teardown", True)
+
+    session.teardown_after_execution(build_init_resource_context())
+
+    assert cleanup_calls == []
 
 
 class LocalSlurmFakeSSHPool:
@@ -1141,6 +1216,41 @@ def test_run_allocation_attaches_to_existing_remote_session(tmp_path: Path):
 
     assert first_allocation.slurm_job_id == second_allocation.slurm_job_id
     assert first_allocation.nodes == second_allocation.nodes
+    assert ssh_pool.submitted_jobs == [700]
+
+
+def test_run_allocation_retry_reattaches_to_tagged_session(tmp_path: Path):
+    ssh_pool = LocalSlurmFakeSSHPool()
+    original_context = SimpleNamespace(
+        run=SimpleNamespace(run_id="original-run", tags={})
+    )
+    original_session = SlurmSessionResource(
+        slurm=_mock_slurm_resource(remote_base=str(tmp_path)),
+        num_nodes=2,
+    )
+    object.__setattr__(
+        original_session,
+        "_ssh_pool",
+        cast(SSHConnectionPool, ssh_pool),
+    )
+    original = original_session._create_allocation(original_context)
+
+    retry_session = SlurmSessionResource(
+        slurm=_mock_slurm_resource(remote_base=str(tmp_path)),
+        num_nodes=2,
+    )
+    object.__setattr__(retry_session, "_ssh_pool", cast(SSHConnectionPool, ssh_pool))
+    retry_context = SimpleNamespace(
+        run=SimpleNamespace(
+            run_id="retry-run",
+            tags={"dagster_slurm/session_allocation_dir": original.working_dir},
+        )
+    )
+
+    reattached = retry_session._create_allocation(retry_context)
+
+    assert reattached.slurm_job_id == original.slurm_job_id
+    assert reattached.working_dir == original.working_dir
     assert ssh_pool.submitted_jobs == [700]
 
 


### PR DESCRIPTION
## Summary

- launch run-scoped allocation steps through detached remote wrappers with durable step-ID, exit-status, stdout, and stderr markers
- persist step identity per asset and keep supervisor heartbeats active so retries reattach to the original allocation and adopt running or successful work without duplicate submission
- preserve allocations across supervisor interruption, propagate recovery metadata through orphan reconciliation, and resubmit only steps with a known failure

## Testing

- 278 unit tests passed; 19 Slurm/slow tests deselected
- Ruff check and format passed
- dprint passed
- ty passed
- full documentation build passed
- Docker Slurm integration tests were not run because no cluster was available

Depends on #208.

Closes #209